### PR TITLE
Add context menu for duplicate, delete and rename mapping

### DIFF
--- a/MainWindow.h
+++ b/MainWindow.h
@@ -88,12 +88,13 @@ private slots:
   void importImage();
   void addColor();
   void about();
-  void updateStatusBar();
   void openRecentFile();
   void clearRecentFileList();
   void openRecentVideo();
   // Edit menu.
   void deleteItem();
+  void cloneItem();
+  void renameItem();
 
   // Widget callbacks.
   void handlePaintItemSelectionChanged();
@@ -172,11 +173,17 @@ public slots:
   /// Deletes/removes a mapping.
   void deleteMapping(uid mappingId);
 
+  /// Clone/duplicate a mapping
+  void cloneMappingItem(uid mappingId);
+
   /// Deletes/removes a paint and all associated mappigns.
   void deletePaint(uid paintId, bool replace);
 
   /// Updates all canvases.
   void updateCanvases();
+
+  // Show Context Menu
+  void showMappingContextMenu(const QPoint &point);
 
 public:
   bool setTextureUri(int texture_id, const std::string &uri);
@@ -191,7 +198,6 @@ private:
   void createMenus();
   void createContextMenu();
   void createToolBars();
-  void createStatusBar();
   void updateRecentFileActions();
   void updateRecentVideoActions();
 
@@ -240,16 +246,13 @@ private:
 
   // Menu actions.
   QMenu *fileMenu;
-//  QMenu *editMenu;
-//  QMenu *selectSubMenu;
-//  QMenu *toolsMenu;
-//  QMenu *optionsMenu;
   QMenu *editMenu;
   QMenu *viewMenu;
   QMenu *runMenu;
   QMenu *helpMenu;
   QMenu *recentFileMenu;
   QMenu *recentVideoMenu;
+  QMenu *contextMenu;
 
   // Toolbar.
   QToolBar *mainToolBar;
@@ -267,10 +270,9 @@ private:
   QAction *exitAction;
   QAction *undoAction;
   QAction *redoAction;
-//  QAction *cutAction;
-//  QAction *copyAction;
-//  QAction *pasteAction;
+  QAction *cloneAction;
   QAction *deleteAction;
+  QAction *renameAction;
   QAction *preferencesAction;
   QAction *aboutAction;
   QAction *clearRecentFileActions;

--- a/MapperGLCanvas.cpp
+++ b/MapperGLCanvas.cpp
@@ -138,7 +138,7 @@ void MapperGLCanvas::mousePressEvent(QMouseEvent* event)
     return;
 
   // Select a shape with a click.
-  if (event->buttons() & Qt::LeftButton)
+  if (event->buttons() & Qt::LeftButton || Qt::RightButton) // Add Right click for context menu
   {
     Shape* orig = getCurrentShape();
     MappingManager manager = getMainWindow()->getMappingManager();
@@ -162,10 +162,13 @@ void MapperGLCanvas::mousePressEvent(QMouseEvent* event)
     }
 
     // Grab the shape.
-    if (orig && orig->includesPoint(_mousePressedPosition))
+    if (event->buttons() & Qt::LeftButton) // This preserve me from duplicate code above
     {
-      _shapeGrabbed = true;
-      _shapeFirstGrab = true;
+      if (orig && orig->includesPoint(_mousePressedPosition))
+      {
+        _shapeGrabbed = true;
+        _shapeFirstGrab = true;
+      }
     }
   }
 

--- a/MappingManager.cpp
+++ b/MappingManager.cpp
@@ -71,8 +71,6 @@ bool MappingManager::removePaint(uid paintId)
     return true;
   }
 
-
-
   return false;
 }
 


### PR DESCRIPTION
It was provided in the Roadmap to copy cut and paste mapping but I thought it was smarter to duplicate the mapping I will explain:
- When cutting a mapping we'll paste it somewhere else but it is just moving from place to place as the mouse can do
- When the coppy is stored in memory the time to paste it somewhere but imagine that we continued created mapping and forget that a mapping that used a lot of memory because it was not used
- Then if we need to copy and paste instantanely we just duplicate/clone the current mapping and if we need to cut and paste all we have to do is move the current mapping with mouse