### PR TITLE
Fix build on GCC 10

### DIFF
--- a/src/gui/MappingItemDelegate.cpp
+++ b/src/gui/MappingItemDelegate.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "MappingItemDelegate.h"
+#include <QPainterPath>
 
 namespace mmp {
 


### PR DESCRIPTION
Include statement missing was causing build to fail. 

Resolves: #516 