### PR TITLE
Install message handler after instanciating MainApplication

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -75,15 +75,16 @@ void logMessageHandler(QtMsgType type, const QMessageLogContext &context, const 
 
 int main(int argc, char *argv[])
 {
-  // Install message handler
-  qInstallMessageHandler(logMessageHandler);
-
   set_env_vars_if_needed();
 
   // Initialize meta-object registry.
   initRegistry();
 
   MainApplication app(argc, argv);
+  
+  // Install message handler
+  // after QGuiApplication has been instanciated
+  qInstallMessageHandler(logMessageHandler);
 
 #if USING_QT_5
   QCommandLineParser parser;


### PR DESCRIPTION
Fix #514 
related to QT bug https://bugreports.qt.io/browse/QTBUG-27024 : "Crash if QGuiApplication::font() is used without instancing QGuiApplication first"