### PR TITLE
Fix macOS build: remove WebEngine dependency and use pkg-config GStreamer

### DIFF
--- a/src/control/qosc/oscreceiver.cpp
+++ b/src/control/qosc/oscreceiver.cpp
@@ -41,7 +41,7 @@ void OscReceiver::byteArrayToVariantList(QVariantList& outputVariantList, QStrin
             } else if (argument.IsString()) {
                 outputVariantList.append(QVariant(argument.AsString()));
             } else if (argument.IsInt32()) {
-                outputVariantList.append(QVariant(argument.AsInt32()));
+                outputVariantList.append(QVariant::fromValue<qint32>(static_cast<qint32>(argument.AsInt32())));
             } else if (argument.IsFloat()) {
                 outputVariantList.append(QVariant(argument.AsFloat()));
             } else if (argument.IsChar()) {

--- a/src/gui/ShortcutWindow.cpp
+++ b/src/gui/ShortcutWindow.cpp
@@ -21,54 +21,70 @@
 
 #include "ConsoleWindow.h"
 #include "MainWindow.h"
+#include <QTextCursor>
+#include <QTextDocument>
+#include <QVBoxLayout>
 
 namespace mmp {
 
-ShortcutWindow::ShortcutWindow()
+ShortcutWindow::ShortcutWindow() :
+  _textBrowser(new QTextBrowser(this))
 {
   // Set window size
   resize(SHORTCUT_WINDOW_WIDTH, SHORTCUT_WINDOW_HEIGHT);
   // Set window title
   setWindowTitle(tr("%1 - Keyboard Shortcuts").arg(MM::APPLICATION_NAME));
-//  setGeometry();
 
-  // Build HTML file to render
-  QString htmlContent("<!DOCTYPE html>\n<html>\n<head>\n");
-  htmlContent.append("<meta charset=\"utf-8\">\n");
-  htmlContent.append("<style>\n");
-  // load CSS file
-  QFile cssFile(":/shortcut-css");
-  cssFile.open(QIODevice::ReadOnly | QIODevice::Text);
-  htmlContent.append(QTextCodec::codecForName("UTF-8")->toUnicode(cssFile.readAll()));
-  htmlContent.append("\n</style>\n");
-  htmlContent.append("</head>\n<body>");
+  QVBoxLayout *layout = new QVBoxLayout(this);
+  layout->setContentsMargins(0, 0, 0, 0);
+  layout->addWidget(_textBrowser);
 
-  // Begining of the body content
-  // Load another HTML file
-  QFile htmlFile(":/index-html");
-  htmlFile.open(QIODevice::ReadOnly | QIODevice::Text);
-  htmlContent.append(QTextCodec::codecForName("UTF-8")->toUnicode(htmlFile.readAll()));
-  // End of body content
-
-  htmlContent.append("</body></html>");
-
-  // Set up web page
-  QWebEnginePage *shortcutWebPage = new QWebEnginePage;
-  shortcutWebPage->setHtml(htmlContent);
-  // Set main page
-  setPage(shortcutWebPage);
-
-  // Disable context menu
-  setContextMenuPolicy(Qt::NoContextMenu);
+  _textBrowser->setOpenExternalLinks(true);
+  _textBrowser->setContextMenuPolicy(Qt::NoContextMenu);
 
   // Create and customize font
   int sansSerif = QFontDatabase::addApplicationFont(":/base-font");
   int serif = QFontDatabase::addApplicationFont(":/console-font");
-  QFont sansSerifFont(QFont(QFontDatabase::applicationFontFamilies(sansSerif).at(0), 11, QFont::Normal));
-  QFont serifFont(QFont(QFontDatabase::applicationFontFamilies(serif).at(0), 10, QFont::Normal));
-  // Apply font to the document
-  settings()->setFontFamily(QWebEngineSettings::SansSerifFont, sansSerifFont.family());
-  settings()->setFontFamily(QWebEngineSettings::SerifFont, serifFont.family());
+  if (sansSerif >= 0)
+  {
+    QFont sansSerifFont(QFont(QFontDatabase::applicationFontFamilies(sansSerif).at(0), 11, QFont::Normal));
+    _textBrowser->document()->setDefaultFont(sansSerifFont);
+  }
+  if (serif >= 0)
+  {
+    QFont serifFont(QFont(QFontDatabase::applicationFontFamilies(serif).at(0), 10, QFont::Normal));
+    _textBrowser->setStyleSheet(QString("pre, code { font-family: '%1'; }").arg(serifFont.family()));
+  }
+
+  reload();
+}
+
+void ShortcutWindow::reload()
+{
+  // Build HTML file to render
+  QString htmlContent("<!DOCTYPE html>\n<html>\n<head>\n");
+  htmlContent.append("<meta charset=\"utf-8\">\n");
+  htmlContent.append("<style>\n");
+
+  // Load CSS file.
+  QFile cssFile(":/shortcut-css");
+  if (cssFile.open(QIODevice::ReadOnly | QIODevice::Text))
+  {
+    htmlContent.append(QTextCodec::codecForName("UTF-8")->toUnicode(cssFile.readAll()));
+  }
+  htmlContent.append("\n</style>\n");
+  htmlContent.append("</head>\n<body>");
+
+  // Beginning of body content.
+  QFile htmlFile(":/index-html");
+  if (htmlFile.open(QIODevice::ReadOnly | QIODevice::Text))
+  {
+    htmlContent.append(QTextCodec::codecForName("UTF-8")->toUnicode(htmlFile.readAll()));
+  }
+  htmlContent.append("</body></html>");
+
+  _textBrowser->setHtml(htmlContent);
+  _textBrowser->moveCursor(QTextCursor::Start);
 
 }
 

--- a/src/gui/ShortcutWindow.h
+++ b/src/gui/ShortcutWindow.h
@@ -19,10 +19,8 @@
 
 #ifndef SHORTCUTWINDOW_H
 #define SHORTCUTWINDOW_H
-
-#include <QWebEngineView>
-#include <QWebEnginePage>
-#include <QWebEngineSettings>
+#include <QDialog>
+#include <QTextBrowser>
 #include <QFile>
 #include <QTextCodec>
 #include <QFontDatabase>
@@ -31,18 +29,20 @@
 
 namespace mmp {
 
-class ShortcutWindow : public QWebEngineView
+class ShortcutWindow : public QDialog
 {
   Q_OBJECT
 public:
   ShortcutWindow();
   ~ShortcutWindow() {}
+  void reload();
 
 private:
 
   // Constantes
   static const int SHORTCUT_WINDOW_WIDTH = 960;
   static const int SHORTCUT_WINDOW_HEIGHT = 640;
+  QTextBrowser *_textBrowser;
 
 };
 

--- a/src/src.pri
+++ b/src/src.pri
@@ -7,7 +7,7 @@ QT += multimedia
 
 greaterThan(QT_MAJOR_VERSION, 4) {
   QT -= gui # using widgets instead gui in Qt5
-  QT += widgets webenginewidgets
+  QT += widgets
 }
 
 #Includes common configuration for all subdirectory .pro files.
@@ -36,8 +36,9 @@ macx {
   DEFINES += MACOSX
   QMAKE_CXXFLAGS += -D__MACOSX_CORE__
   QMAKE_CXXFLAGS += -stdlib=libc++
-  INCLUDEPATH += /Library/Frameworks/GStreamer.framework/Versions/1.0/Headers
-  LIBS += -F /Library/Frameworks/ -framework GStreamer
+  CONFIG += link_pkgconfig
+  PKGCONFIG += \
+    gstreamer-1.0 gstreamer-base-1.0 gstreamer-app-1.0 gstreamer-pbutils-1.0
   LIBS += -framework OpenGL -framework GLUT
   # With Xcode Tools > 1.5, to reduce the size of your binary even more:
   # LIBS += -dead_strip


### PR DESCRIPTION
## Summary
- Replace `QWebEngineView` with `QTextBrowser` in `ShortcutWindow` to remove the QtWebEngine dependency, which causes build failures on modern macOS
- Switch macOS GStreamer linking from hardcoded framework path to `pkg-config`, supporting Homebrew and other standard installations
- Fix deprecated `QVariant(int)` constructor warning in OSC receiver

## Test plan
- [x] Build on macOS with Homebrew-installed GStreamer
- [ ] Verify the keyboard shortcuts window displays correctly
- [ ] Verify OSC message receiving still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)