### PR TITLE
Make it less verbose

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -110,6 +110,11 @@ int main(int argc, char *argv[])
     "Use language <lang>.", "lang", "");
   parser.addOption(localeOption);
 
+  // --verbose option
+  QCommandLineOption verboseOption(QStringList() << "V" << "verbose",
+    "Enable verbose output, including OSC message logging.");
+  parser.addOption(verboseOption);
+
   // --frame-rate option
   QCommandLineOption frameRateOption(QStringList() << "r" << "frame-rate",
     "Use a framerate of <frame-rate> per second.", "frame-rate", QString::number(MM::DEFAULT_FRAMES_PER_SECOND));
@@ -204,6 +209,9 @@ int main(int argc, char *argv[])
   QString oscPortValue = parser.value("osc-port");
   if (oscPortValue != "")
     win->setOscPort(oscPortValue);
+
+  if (parser.isSet(verboseOption))
+    win->setVerbose(true);
 
   bool optionOk;
   qreal fps = parser.value("frame-rate").toDouble(&optionOk);

--- a/src/control/OscInterface.cpp
+++ b/src/control/OscInterface.cpp
@@ -148,9 +148,8 @@ static void printCommand(QVariantList &command)
 
 void OscInterface::applyOscCommand(MainWindow &main_window, QVariantList & command) {
   Q_UNUSED(main_window);
-  bool VERBOSE = false;
 
-  if (VERBOSE)
+  if (is_verbose())
   {
     std::cout << "OscInterface::applyOscCommand: Receive OSC: " << std::endl;
     printCommand(command);
@@ -211,7 +210,8 @@ void OscInterface::applyOscCommand(MainWindow &main_window, QVariantList & comma
             }
             // Property setting (eg. opacity)
             else if (command.size() >= 4) {
-              qDebug() << "Attempt to set a source property" << iterator.first << command.at(3);
+              if (is_verbose())
+                qDebug() << "Attempt to set a source property" << iterator.first << command.at(3);
               pathIsValid |= setElementProperty(elem, iterator.first, command.at(3));
             }
           }
@@ -266,7 +266,7 @@ void OscInterface::applyOscCommand(MainWindow &main_window, QVariantList & comma
     }
   }
 
-  if (! pathIsValid)
+  if (! pathIsValid && is_verbose())
   {
     qDebug() << "Path could not be processed: " << path << Qt::endl;
     printCommand(command);

--- a/src/control/OscInterface.h
+++ b/src/control/OscInterface.h
@@ -45,6 +45,8 @@ public:
   OscInterface(int listen_port);
   ~OscInterface();
 
+  void setVerbose(bool verbose) { verbose_ = verbose; }
+
   /// Starts listening if receiving is enabled.
   void start();
 
@@ -59,9 +61,10 @@ public:
   // FIXME use QObject signals instead of polling
 
 private:
-  bool is_verbose() const { return false; }
+  bool is_verbose() const { return verbose_; }
   void push_command(QVariantList command);
 
+  bool verbose_ = false;
   bool receiving_enabled_;
   OscReceiver receiver_;
   ConcurrentQueue<QVariantList> messaging_queue_;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3714,6 +3714,12 @@ int MainWindow::getOscPort() const
   return oscListeningPort;
 }
 
+void MainWindow::setVerbose(bool verbose)
+{
+  if (osc_interface)
+    osc_interface->setVerbose(verbose);
+}
+
 bool MainWindow::setOscPort(QString portNumber)
 {
   bool ok;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -623,6 +623,7 @@ public:
   bool setOscPort(QString portNumber);
   bool setOscPort(int portNumber);
   int getOscPort() const;
+  void setVerbose(bool verbose);
   void setOutputWindowFullScreen(bool enable);
 
 public:


### PR DESCRIPTION
OSC message logging on every received message was slowing things down. Now only printed when running with -V/--verbose. Off by default.