### PR TITLE
Production-readiness audit: OSC/MCP hardening, i18n, signal/slot migration, onboarding

### DIFF
--- a/docs/datasheet.rst
+++ b/docs/datasheet.rst
@@ -9,8 +9,8 @@ MapMap allows its users to:
 * Create and destroy an unlimited amount of mappings. Each mapping is a shape on which a source paint is drawn.
 * Color paints can be used as masks.
 * Move layers.
-* Save the project to a human-readable XML file.
-* Load the project from a human-readable XML file.
+* Save the project to a human-readable JSON file.
+* Load the project from a human-readable JSON file.
 * Turn any quad into a mesh.
 * Inspect properties.
 

--- a/docs/informations/osc.md
+++ b/docs/informations/osc.md
@@ -57,3 +57,14 @@ Pause: `/mapmap/pause`
 Play: `/mapmap/play`  
 Rewind/reset: `/mapmap/rewind`  
 Quit: `/mapmap/quit`
+
+## Security
+
+OSC has no authentication. By default MapMap listens on the loopback
+interface only (`127.0.0.1`), so OSC is reachable solely from the same
+computer. To control MapMap from another device, enable **Accept OSC from
+the network** in *Preferences > OSC Setup* — only on a trusted show network.
+
+The `/mapmap/quit` command is ignored unless **Allow OSC to quit the
+application** is enabled in the same panel, so a remote sender cannot close
+the app during a show.

--- a/docs/manual/manual_en.rst
+++ b/docs/manual/manual_en.rst
@@ -49,7 +49,7 @@ Paints can be destroyed simply by selecting it in the paint list, and then choos
 
 Save the project to a file
 --------------------------
-To save the current project, choose "File > Save as..." and then choose a file name. The extension file is ".mmp", but the file format is simply XML, a very common one.
+To save the current project, choose "File > Save as..." and then choose a file name. The extension file is ".mmp", but the file format is simply JSON, a very common one.
 
 Load a project from a file
 --------------------------

--- a/mapmap.pro
+++ b/mapmap.pro
@@ -4,11 +4,16 @@ CONFIG += c++17
 
 TEMPLATE = app
 
-# Always use major.minor.micro version number format
-VERSION = 0.6.3
+# Always use major.minor.micro version number format (kept numeric so bundle
+# and library versioning stay valid).
+VERSION = 1.0.0
+# Human-facing version shown in-app (About box, window title, app version).
+# Single source of truth for MM::VERSION, injected via DEFINES below.
+MAPMAP_VERSION = 1.0.0-alpha.1
 TARGET = mapmap
 
 DEFINES += UNICODE QT_THREAD_SUPPORT QT_CORE_LIB QT_GUI_LIB QT_MESSAGELOGCONTEXT
+DEFINES += MAPMAP_VERSION_STRING=\\\"$$MAPMAP_VERSION\\\"
 
 include(src/core/core.pri)
 include(src/shape/shape.pri)

--- a/src/app/MainApplication.cpp
+++ b/src/app/MainApplication.cpp
@@ -44,14 +44,23 @@ MainApplication::~MainApplication()
 
 bool MainApplication::notify(QObject *receiver, QEvent *event)
 {
+  // Last-resort guard: a stray exception during event delivery must never take
+  // down a running show. Log loudly (qCritical survives in release builds,
+  // unlike qDebug) and drop the offending event instead of terminating.
+  const int eventType = event ? static_cast<int>(event->type()) : -1;
   try
   {
     return QApplication::notify(receiver, event);
   }
-  catch (std::exception &ex)
+  catch (const std::exception &ex)
   {
-    qDebug() << "std::exception was caught: " << ex.what() << Qt::endl;
-    qDebug() << "event type: " << event->type() << Qt::endl;
+    qCritical() << "Unhandled std::exception during event delivery:" << ex.what()
+                << "(event type" << eventType << ")";
+  }
+  catch (...)
+  {
+    qCritical() << "Unhandled non-standard exception during event delivery"
+                << "(event type" << eventType << ")";
   }
 
   return false;

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -195,7 +195,8 @@ int main(int argc, char *argv[])
 
   // Load stylesheet.
   QFile stylesheet(":/stylesheet");
-  (void)stylesheet.open(QFile::ReadOnly);
+  if (!stylesheet.open(QFile::ReadOnly))
+    qWarning() << "Could not open embedded stylesheet" << stylesheet.fileName();
   app.setStyleSheet(QLatin1String(stylesheet.readAll()));
 
   // read positional argument:

--- a/src/control/McpServer.cpp
+++ b/src/control/McpServer.cpp
@@ -23,6 +23,7 @@
 #include <QHttpServerRequest>
 #include <QHttpServerResponse>
 #include <QHostAddress>
+#include <QUuid>
 #include <QTcpServer>
 #include <QJsonDocument>
 #include <QMetaObject>
@@ -40,9 +41,38 @@
 
 namespace mmp {
 
+namespace {
+// Host/Origin values that identify the local machine, used to reject
+// DNS-rebinding and cross-origin requests to the control surface.
+bool isLoopbackHost(QByteArray host)
+{
+  host = host.trimmed();
+  if (host.startsWith('['))            // IPv6 literal, e.g. [::1]:port
+  {
+    const int end = host.indexOf(']');
+    if (end > 0) host = host.mid(1, end - 1);
+  }
+  else                                 // host:port
+  {
+    const int colon = host.indexOf(':');
+    if (colon >= 0) host = host.left(colon);
+  }
+  return host == "localhost" || host == "127.0.0.1" || host == "::1";
+}
+
+bool isLoopbackOrigin(QByteArray origin)
+{
+  const int scheme = origin.indexOf("://");
+  if (scheme >= 0) origin = origin.mid(scheme + 3);
+  return isLoopbackHost(origin);
+}
+} // namespace
+
 McpServer::McpServer(MainWindow* mainWindow, QObject* parent)
   : QObject(parent), _mainWindow(mainWindow), _httpServer(nullptr), _port(0)
 {
+  // Per-process shared secret required on every request (see isAuthorized).
+  _token = QUuid::createUuid().toString(QUuid::WithoutBraces);
 }
 
 McpServer::~McpServer()
@@ -61,6 +91,9 @@ quint16 McpServer::start(quint16 port)
     if (request.method() != QHttpServerRequest::Method::Post)
       return QHttpServerResponse("text/plain", QByteArray("Method Not Allowed"),
                                  QHttpServerResponse::StatusCode::MethodNotAllowed);
+    if (!isAuthorized(request))
+      return QHttpServerResponse("text/plain", QByteArray("Forbidden"),
+                                 QHttpServerResponse::StatusCode::Forbidden);
     const QByteArray out = handleRpc(request.body());
     if (out.isEmpty()) // notification: acknowledge with no body
       return QHttpServerResponse(QHttpServerResponse::StatusCode::Accepted);
@@ -83,6 +116,19 @@ quint16 McpServer::start(quint16 port)
 bool McpServer::isListening() const
 {
   return _httpServer != nullptr && _port != 0;
+}
+
+bool McpServer::isAuthorized(const QHttpServerRequest& request) const
+{
+  // 1. DNS-rebinding guard: the Host header must name the loopback interface.
+  if (!isLoopbackHost(request.value("Host")))
+    return false;
+  // 2. If a browser sent an Origin, it must be loopback too ("null" is allowed).
+  const QByteArray origin = request.value("Origin");
+  if (!origin.isEmpty() && origin != "null" && !isLoopbackOrigin(origin))
+    return false;
+  // 3. Shared-secret bearer token generated at startup.
+  return request.value("Authorization") == QByteArray("Bearer ") + _token.toUtf8();
 }
 
 QByteArray McpServer::handleRpc(const QByteArray& body)

--- a/src/control/McpServer.h
+++ b/src/control/McpServer.h
@@ -30,6 +30,7 @@
 
 QT_BEGIN_NAMESPACE
 class QHttpServer;
+class QHttpServerRequest;
 QT_END_NAMESPACE
 
 namespace mmp {
@@ -56,11 +57,18 @@ public:
   /// Currently bound port (0 if not listening).
   quint16 port() const { return _port; }
 
+  /// Bearer token that every request must present in its Authorization header.
+  QString token() const { return _token; }
+
 private:
   // --- JSON-RPC plumbing ---
   // Returns the response body, or an empty array for notifications (no reply).
   QByteArray handleRpc(const QByteArray& body);
   QJsonObject dispatch(const QJsonObject& request);
+
+  // Rejects requests that are non-loopback (DNS-rebinding), cross-origin, or
+  // missing the bearer token.
+  bool isAuthorized(const QHttpServerRequest& request) const;
 
   static QJsonObject makeResult(const QJsonValue& id, const QJsonValue& result);
   static QJsonObject makeError(const QJsonValue& id, int code, const QString& message);
@@ -83,6 +91,7 @@ private:
   MainWindow* _mainWindow;
   QHttpServer* _httpServer;
   quint16 _port;
+  QString _token;
 };
 
 }

--- a/src/control/OscInterface.cpp
+++ b/src/control/OscInterface.cpp
@@ -219,7 +219,11 @@ bool OscInterface::applyAction(MainWindow &main_window, const OscAction& action)
     return false;
 
   // Global transport.
-  case OscAction::Quit:      main_window.close();  return true;
+  case OscAction::Quit:
+    if (main_window.isOscQuitAllowed()) { main_window.close(); return true; }
+    qWarning() << "Ignoring OSC /mapmap/quit: remote quit is disabled "
+                  "(enable it in Preferences > OSC Setup).";
+    return false;
   case OscAction::PlayAll:   main_window.play();   return true;
   case OscAction::PauseAll:  main_window.pause();  return true;
   case OscAction::RewindAll: main_window.rewind(); return true;

--- a/src/control/OscInterface.cpp
+++ b/src/control/OscInterface.cpp
@@ -75,8 +75,8 @@ QVector<Layer::ptr> resolveLayers(MappingManager& manager, const OscAction& acti
 } // namespace
 
 OscInterface::OscInterface(
-    int listen_port) :
-    receiver_(listen_port),
+    int listen_port, bool acceptFromNetwork) :
+    receiver_(listen_port, acceptFromNetwork),
     messaging_queue_() {
   receiving_enabled_ = true;
   if (receiving_enabled_) {

--- a/src/control/OscInterface.h
+++ b/src/control/OscInterface.h
@@ -42,7 +42,7 @@ class OscInterface {
 public:
   typedef QSharedPointer<OscInterface> ptr;
 
-  OscInterface(int listen_port);
+  OscInterface(int listen_port, bool acceptFromNetwork = false);
   ~OscInterface();
 
   void setVerbose(bool verbose) { verbose_ = verbose; }

--- a/src/control/OscInterface.h
+++ b/src/control/OscInterface.h
@@ -45,7 +45,7 @@ public:
   OscInterface(int listen_port, bool acceptFromNetwork = false);
   ~OscInterface();
 
-  void setVerbose(bool verbose) { verbose_ = verbose; }
+  void setVerbose(bool verbose) { verbose_ = verbose; receiver_.setVerbose(verbose); }
 
   /// Starts listening if receiving is enabled.
   void start();

--- a/src/control/qosc/oscreceiver.cpp
+++ b/src/control/qosc/oscreceiver.cpp
@@ -32,7 +32,8 @@ void OscReceiver::readyReadCb() {
         // message when it parsed cleanly, and keep draining the queue otherwise.
         if (this->byteArrayToVariantList(arguments, oscAddress, data)) {
             emit messageReceived(oscAddress, arguments);
-            qDebug() << "C++OscReceiver Received: " << oscAddress << arguments;
+            if (m_verbose)
+                qDebug() << "OscReceiver received:" << oscAddress << arguments;
         }
     }
 }

--- a/src/control/qosc/oscreceiver.cpp
+++ b/src/control/qosc/oscreceiver.cpp
@@ -3,13 +3,21 @@
 #include "contrib/oscpack/OscReceivedElements.h"
 #include "contrib/oscpack/OscException.h"
 
-OscReceiver::OscReceiver(quint16 receivePort, QObject* parent) :
+OscReceiver::OscReceiver(quint16 receivePort, bool acceptFromNetwork, QObject* parent) :
         QObject(parent)
 {
     m_udpSocket = new QUdpSocket(this);
-    // m_udpSocket->bind(QHostAddress::LocalHost, receivePort);
-    qDebug() << "Listening for OSC on " << receivePort;
-    m_udpSocket->bind(QHostAddress::Any, receivePort);
+    // OSC has no authentication, so bind to loopback by default: the control
+    // surface must not be reachable from the venue network unless the user
+    // explicitly opts in (Preferences > OSC Setup).
+    const QHostAddress bindAddress = acceptFromNetwork ? QHostAddress(QHostAddress::Any)
+                                                       : QHostAddress(QHostAddress::LocalHost);
+    if (!m_udpSocket->bind(bindAddress, receivePort)) {
+        qWarning() << "OscReceiver: could not bind OSC port" << receivePort
+                   << "on" << bindAddress.toString();
+    } else {
+        qInfo() << "Listening for OSC on" << bindAddress.toString() << "port" << receivePort;
+    }
     connect(m_udpSocket, &QUdpSocket::readyRead, this, &OscReceiver::readyReadCb);
 }
 

--- a/src/control/qosc/oscreceiver.cpp
+++ b/src/control/qosc/oscreceiver.cpp
@@ -1,6 +1,7 @@
 #include "oscreceiver.h"
 #include "contrib/oscpack/OscTypes.h"
 #include "contrib/oscpack/OscReceivedElements.h"
+#include "contrib/oscpack/OscException.h"
 
 OscReceiver::OscReceiver(quint16 receivePort, QObject* parent) :
         QObject(parent)
@@ -19,39 +20,50 @@ void OscReceiver::readyReadCb() {
         QByteArray data = datagram.data();
         QVariantList arguments;
         QString oscAddress;
-        this->byteArrayToVariantList(arguments, oscAddress, data);
-        emit messageReceived(oscAddress, arguments);
-        qDebug() << "C++OscReceiver Received: " << oscAddress << arguments;
+        // A malformed datagram must never take the app down: only forward the
+        // message when it parsed cleanly, and keep draining the queue otherwise.
+        if (this->byteArrayToVariantList(arguments, oscAddress, data)) {
+            emit messageReceived(oscAddress, arguments);
+            qDebug() << "C++OscReceiver Received: " << oscAddress << arguments;
+        }
     }
 }
 
-void OscReceiver::byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray) {
-    osc::ReceivedPacket packet(inputByteArray.data(), static_cast<std::size_t>(inputByteArray.size()));
-    // TODO: catch parsing exceptions
-    if (packet.IsMessage()) {
-        osc::ReceivedMessage message(packet);
-        // Get address pattern
-        QString address(message.AddressPattern());
-        outputOscAddress.replace(0, address.size(), address);
+bool OscReceiver::byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray) {
+    // oscpack throws osc::Exception (derived from std::exception) on any
+    // malformed input. Catch it here so a single bad datagram is dropped
+    // rather than unwinding through the Qt event loop.
+    try {
+        osc::ReceivedPacket packet(inputByteArray.data(), static_cast<std::size_t>(inputByteArray.size()));
+        if (packet.IsMessage()) {
+            osc::ReceivedMessage message(packet);
+            // Get address pattern
+            QString address(message.AddressPattern());
+            outputOscAddress.replace(0, address.size(), address);
 
-        for (auto iter = message.ArgumentsBegin(); iter != message.ArgumentsEnd(); ++ iter) {
-            osc::ReceivedMessageArgument argument = (*iter);
-            if (argument.IsBool()) {
-                outputVariantList.append(QVariant(argument.AsBool()));
-            } else if (argument.IsString()) {
-                outputVariantList.append(QVariant(argument.AsString()));
-            } else if (argument.IsInt32()) {
-                outputVariantList.append(QVariant::fromValue<qint32>(static_cast<qint32>(argument.AsInt32())));
-            } else if (argument.IsFloat()) {
-                outputVariantList.append(QVariant(argument.AsFloat()));
-            } else if (argument.IsChar()) {
-                outputVariantList.append(QVariant(argument.AsChar()));
-            //} else if (argument.IsInt64()) {
-            //    outputVariantList.append(QVariant(argument.AsInt64()));
-            } else if (argument.IsDouble()) {
-                outputVariantList.append(QVariant(argument.AsDouble()));
+            for (auto iter = message.ArgumentsBegin(); iter != message.ArgumentsEnd(); ++ iter) {
+                osc::ReceivedMessageArgument argument = (*iter);
+                if (argument.IsBool()) {
+                    outputVariantList.append(QVariant(argument.AsBool()));
+                } else if (argument.IsString()) {
+                    outputVariantList.append(QVariant(argument.AsString()));
+                } else if (argument.IsInt32()) {
+                    outputVariantList.append(QVariant::fromValue<qint32>(static_cast<qint32>(argument.AsInt32())));
+                } else if (argument.IsFloat()) {
+                    outputVariantList.append(QVariant(argument.AsFloat()));
+                } else if (argument.IsChar()) {
+                    outputVariantList.append(QVariant(argument.AsChar()));
+                //} else if (argument.IsInt64()) {
+                //    outputVariantList.append(QVariant(argument.AsInt64()));
+                } else if (argument.IsDouble()) {
+                    outputVariantList.append(QVariant(argument.AsDouble()));
+                }
+                // TODO: support Array, Midi, Blob, Symbol, TimeTag, RGBA, Nil
             }
-            // TODO: support Array, Midi, Blob, Symbol, TimeTag, RGBA, Nil
-        }
-    } // TODO: also parse bundles
+        } // TODO: also parse bundles
+    } catch (const osc::Exception& e) {
+        qWarning() << "OscReceiver: dropped malformed OSC packet:" << e.what();
+        return false;
+    }
+    return true;
 }

--- a/src/control/qosc/oscreceiver.h
+++ b/src/control/qosc/oscreceiver.h
@@ -41,7 +41,7 @@ public slots:
 
 private:
     QUdpSocket* m_udpSocket;
-    void byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
+    bool byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
 };
 
 #endif // OSCRECEIVER_H

--- a/src/control/qosc/oscreceiver.h
+++ b/src/control/qosc/oscreceiver.h
@@ -28,6 +28,10 @@ public:
      */
     explicit OscReceiver(quint16 receivePort, bool acceptFromNetwork = false, QObject *parent = nullptr);
 
+    /// When false (default), per-message receive logging is suppressed to keep
+    /// the hot path quiet under high OSC rates.
+    void setVerbose(bool verbose) { m_verbose = verbose; }
+
 signals:
     /**
      * @brief Signal triggered each time we receive a message.
@@ -41,6 +45,7 @@ public slots:
 
 private:
     QUdpSocket* m_udpSocket;
+    bool m_verbose = false;
     bool byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
 };
 

--- a/src/control/qosc/oscreceiver.h
+++ b/src/control/qosc/oscreceiver.h
@@ -26,7 +26,7 @@ public:
      * @brief Constructor.
      * @param receivePort Port number to listen to.
      */
-    explicit OscReceiver(quint16 receivePort, QObject *parent = nullptr);
+    explicit OscReceiver(quint16 receivePort, bool acceptFromNetwork = false, QObject *parent = nullptr);
 
 signals:
     /**

--- a/src/core/MM.cpp
+++ b/src/core/MM.cpp
@@ -23,7 +23,13 @@
 namespace mmp {
 
 const QString MM::APPLICATION_NAME = "MapMap";
-const QString MM::VERSION = "0.6.3";
+// Single source of truth is MAPMAP_VERSION in mapmap.pro, injected via DEFINES.
+// The literal fallback keeps direct compiles working and must match the .pro.
+#ifdef MAPMAP_VERSION_STRING
+const QString MM::VERSION = MAPMAP_VERSION_STRING;
+#else
+const QString MM::VERSION = "1.0.0-alpha.1";
+#endif
 const QString MM::COPYRIGHT_OWNERS = "Alexandre Quessy, Sofian Audry, Dame Diongue, Mike Latona, Vasilis Liaskovitis";
 const QString MM::ORGANIZATION_NAME = "MapMap";
 const QString MM::ORGANIZATION_DOMAIN = "artpluscode.com";
@@ -42,7 +48,9 @@ const QString MM::VIDEO_FILES_FILTER = "*.mov *.mp4 *.avi *.ogg *.ogv *.mpeg *.m
 const QString MM::IMAGE_FILES_FILTER = "*.jpg *.jpeg *.gif *.png *.tiff *.tif *.bmp";
 const QString MM::NAMESPACE_PREFIX = QString("%1::").arg(TOSTRING(MM_NAMESPACE));
 const QString MM::SUPPORTED_LANGUAGES = "en, es, fr, zh_CN, zh_TW";
-const QString MM::SUPPORTED_FILE_VERSIONS = "\\d+\\.\\d+\\.\\d+"; // regex
+// x.y.z with an optional -prerelease / +build suffix (e.g. 1.0.0-alpha.1), so
+// projects saved by pre-release builds remain loadable. Anchored to reject junk.
+const QString MM::SUPPORTED_FILE_VERSIONS = "^\\d+\\.\\d+\\.\\d+([-+][0-9A-Za-z.-]+)?$"; // regex
 
 const QColor MM::WHITE("#f6f5f5");
 const QColor MM::BLUE_GRAY("#323541");

--- a/src/core/MM.h
+++ b/src/core/MM.h
@@ -79,9 +79,10 @@ public:
   // OSC
   static const int DEFAULT_OSC_PORT = 12345;
 
-  // MCP (Model Context Protocol) server. Uses a port in the IANA
-  // dynamic/private range (49152-65535) to minimise collisions.
-  static const int DEFAULT_MCP_PORT = 49452;
+  // MCP (Model Context Protocol) server. Disabled by default (0): the user
+  // opts in by setting a port in Preferences > MCP Setup. A good enabled value
+  // is one in the IANA dynamic/private range (49152-65535), e.g. 49452.
+  static const int DEFAULT_MCP_PORT = 0;
 
   // Default values
   static const bool DISPLAY_TEST_SIGNAL = false;

--- a/src/core/ProjectReader.cpp
+++ b/src/core/ProjectReader.cpp
@@ -87,19 +87,19 @@ void ProjectReader::parseProject(const QJsonObject& project)
       manager.addSource(source);
       _window->addSourceItem(source->getId(), source->getIcon(), source->getName());
 
-      // Locate media file if not found
+      // Locate media file if not found. Guard the cast: a source that claims
+      // to be Video/Image but cannot be cast (corrupt entry) must not be
+      // dereferenced — Q_CHECK_PTR is a no-op in release builds.
       if (source->getSourceType() == Source::SourceType::Video)
       {
         QSharedPointer<Video> media = qSharedPointerCast<Video>(source);
-        Q_CHECK_PTR(media);
-        if (!_window->fileExists(media->getUri()))
+        if (!media.isNull() && !_window->fileExists(media->getUri()))
           media->setUri(_window->locateMediaFile(media->getUri(), false));
       }
       if (source->getSourceType() == Source::SourceType::Image)
       {
         QSharedPointer<Image> image = qSharedPointerCast<Image>(source);
-        Q_CHECK_PTR(image);
-        if (!_window->fileExists(image->getUri()))
+        if (!image.isNull() && !_window->fileExists(image->getUri()))
           image->setUri(_window->locateMediaFile(image->getUri(), true));
       }
     }

--- a/src/core/ProjectReader.cpp
+++ b/src/core/ProjectReader.cpp
@@ -143,13 +143,14 @@ Source::ptr ProjectReader::parseSource(const QJsonObject& obj)
 
     if (source.isNull())
     {
-      qDebug() << QObject::tr("Problem at creation of source.") << Qt::endl;
+      // Registered type that could not be instantiated (malformed or
+      // incompatible entry). Bail out instead of dereferencing a null source.
+      qWarning() << "Could not instantiate source of type" << className;
+      return Source::ptr();
     }
-    else
-      qDebug() << "Created new instance with id: " << source->getId();
 
+    qDebug() << "Created new instance with id: " << source->getId();
     source->read(obj);
-
     return source;
   }
   else
@@ -172,11 +173,13 @@ Layer::ptr ProjectReader::parseLayer(const QJsonObject& obj)
     Layer::ptr layer(qobject_cast<Layer*>(metaObject->newInstance(Q_ARG(int, id))));
     if (layer.isNull())
     {
-      qDebug() << QObject::tr("Problem at creation of layer.") << Qt::endl;
+      // Registered type that could not be instantiated. Report and bail out
+      // instead of dereferencing a null layer.
+      _errorString = QObject::tr("Unable to create layer of type '%1'.").arg(className);
+      return Layer::ptr();
     }
 
     layer->read(obj);
-
     return layer;
   }
   else

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -56,7 +56,7 @@ AboutDialog::AboutDialog(QWidget *parent) : QDialog(parent)
 
   // Close button
   QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
-  connect(buttonBox, SIGNAL(rejected()), this, SLOT(close()));
+  connect(buttonBox, &QDialogButtonBox::rejected, this, &QWidget::close);
   mainLayout->addWidget(buttonBox, 2, 0, 1, 4);
 
   // Create and fill different tabs

--- a/src/gui/AboutDialog.cpp
+++ b/src/gui/AboutDialog.cpp
@@ -95,11 +95,13 @@ void AboutDialog::createAboutTab()
   QString copyrightText = "<p>" + tr("Copyright &copy; 2013 %1.").arg(MM::COPYRIGHT_OWNERS) + "</p>";
   // License short notice
   QFile licenseShortFile(":/license-short");
-  (void)licenseShortFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  if (!licenseShortFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    qWarning() << "AboutDialog: could not open" << licenseShortFile.fileName();
   QString licenseNoticeText = Qt::convertFromPlainText(QString::fromUtf8(licenseShortFile.readAll()), Qt::WhiteSpaceNormal);
   // About projection mapping
   QFile aboutMappingFile(":/projection-mapping");
-  (void)aboutMappingFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  if (!aboutMappingFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    qWarning() << "AboutDialog: could not open" << aboutMappingFile.fileName();
   QString aboutMappingText = QString::fromUtf8(aboutMappingFile.readAll());
   // Visit our website for more information
   QString projectWebsiteText = "<p>" + tr("See the ") + QString("<a href=\"%1\">").arg(MM::WEBSITE_URL) +
@@ -136,7 +138,8 @@ void AboutDialog::createChangelogTab()
   changelogTextBrowser->setOpenExternalLinks(true);
 
   QFile changelogFile(":/changelog_md");
-  (void)changelogFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  if (!changelogFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    qWarning() << "AboutDialog: could not open" << changelogFile.fileName();
   changelogTextBrowser->setMarkdown(QString::fromUtf8(changelogFile.readAll()));
   _tabWidget->addTab(changelogTextBrowser, tr("Changelog"));
 }
@@ -173,7 +176,8 @@ void AboutDialog::createLicenseTab()
   licenseTextBrowser->setOpenExternalLinks(true);
 
   QFile licenseFile(":/license");
-  (void)licenseFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  if (!licenseFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    qWarning() << "AboutDialog: could not open" << licenseFile.fileName();
   licenseTextBrowser->setText(QString::fromUtf8(licenseFile.readAll()));
 
   _tabWidget->addTab(licenseTextBrowser, tr("License"));
@@ -186,7 +190,8 @@ void AboutDialog::createOscTab()
   oscBrowser->setOpenExternalLinks(true);
 
   QFile oscFile(":/osc-documentation_md");
-  (void)oscFile.open(QIODevice::ReadOnly | QIODevice::Text);
+  if (!oscFile.open(QIODevice::ReadOnly | QIODevice::Text))
+    qWarning() << "AboutDialog: could not open" << oscFile.fileName();
   oscBrowser->setMarkdown(QString::fromUtf8(oscFile.readAll()));
   _tabWidget->addTab(oscBrowser, tr("OSC Commands"));
 }

--- a/src/gui/ConsoleWindow.cpp
+++ b/src/gui/ConsoleWindow.cpp
@@ -86,7 +86,10 @@ void ConsoleWindow::writeLogFile(const QString &message)
 {
   QString logFilePath = QDir(QDir::tempPath()).filePath("mapmap.log");
   QFile logFile(logFilePath);
-  (void)logFile.open(QIODevice::Append);
+  // Don't qWarning() on failure: printMessage() routes warnings back here and
+  // would recurse. Silently skip writing if the log file can't be opened.
+  if (!logFile.open(QIODevice::Append))
+    return;
   QTextStream stream(&logFile);
   stream << message << Qt::endl;
 }

--- a/src/gui/ConsoleWindow.cpp
+++ b/src/gui/ConsoleWindow.cpp
@@ -71,7 +71,7 @@ void ConsoleWindow::createActions()
   quitAction = new QAction(tr("&Close"), this);
   quitAction->setShortcut(QKeySequence::Close);
   quitAction->setStatusTip(tr("Close the console"));
-  connect(quitAction, SIGNAL(triggered(bool)), this, SLOT(close()));
+  connect(quitAction, &QAction::triggered, this, &QWidget::close);
 }
 
 void ConsoleWindow::createMenu()

--- a/src/gui/LayerGui.cpp
+++ b/src/gui/LayerGui.cpp
@@ -68,8 +68,8 @@ LayerGui::LayerGui(Layer::ptr layer)
   // Collapse output shape.
   _propertyBrowser->setExpanded(_propertyBrowser->items(_outputItem).at(0), false);
 
-  connect(_variantManager, SIGNAL(valueChanged(QtProperty*, const QVariant&)),
-          this,            SLOT(setValue(QtProperty*, const QVariant&)));
+  connect(_variantManager, &QtVariantPropertyManager::valueChanged,
+          this, qOverload<QtProperty*, const QVariant&>(&LayerGui::setValue));
   //qDebug() << "Creating mapper" << endl;
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2714,6 +2714,7 @@ void MainWindow::readSettings()
   outputWindow->setCanvasDisplayCrosshair(settings.value("displayControls", MM::DISPLAY_CONTROLS).toBool());
   oscListeningPort = settings.value("oscListeningPort", MM::DEFAULT_OSC_PORT).toInt();
   oscAcceptNetwork = settings.value("oscAcceptNetwork", false).toBool();
+  oscAllowQuit = settings.value("oscAllowQuit", false).toBool();
 #ifdef HAVE_MCP
   mcpListeningPort = settings.value("mcpListeningPort", MM::DEFAULT_MCP_PORT).toInt();
 #endif
@@ -2751,6 +2752,7 @@ void MainWindow::writeSettings()
   settings.setValue("displayAllControls", displaySourceControlsAction->isChecked());
   settings.setValue("oscListeningPort", oscListeningPort);
   settings.setValue("oscAcceptNetwork", oscAcceptNetwork);
+  settings.setValue("oscAllowQuit", oscAllowQuit);
 #ifdef HAVE_MCP
   settings.setValue("mcpListeningPort", mcpListeningPort);
 #endif

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1800,7 +1800,7 @@ void MainWindow::createActions()
   connect(newAction, &QAction::triggered, this, &MainWindow::newFile);
 
   // Open.
-  openAction = new QAction(tr("&Open..."), this);
+  openAction = new QAction(tr("&Open…"), this);
   openAction->setIcon(QIcon(":/open"));
   openAction->setShortcut(QKeySequence::Open);
   openAction->setToolTip(tr("Open an existing project"));
@@ -1820,10 +1820,10 @@ void MainWindow::createActions()
   connect(saveAction, &QAction::triggered, this, &MainWindow::save);
 
   // Save as.
-  saveAsAction = new QAction(tr("Save &As..."), this);
+  saveAsAction = new QAction(tr("Save &As…"), this);
   saveAsAction->setIcon(QIcon(":/save-as"));
   saveAsAction->setShortcut(QKeySequence::SaveAs);
-  saveAsAction->setToolTip(tr("Save the project as..."));
+  saveAsAction->setToolTip(tr("Save the project as…"));
   saveAsAction->setIconVisibleInMenu(false);
   saveAsAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(saveAsAction);
@@ -1856,30 +1856,30 @@ void MainWindow::createActions()
 
 
   // Import Media.
-  importMediaAction = new QAction(tr("&Import Media File..."), this);
+  importMediaAction = new QAction(tr("&Import Media File…"), this);
   importMediaAction->setShortcut(Qt::CTRL | Qt::Key_I);
   importMediaAction->setIcon(QIcon(":/add-video"));
-  importMediaAction->setToolTip(tr("Import a video or image file..."));
+  importMediaAction->setToolTip(tr("Import a video or image file…"));
   importMediaAction->setIconVisibleInMenu(false);
   importMediaAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(importMediaAction);
   connect(importMediaAction, &QAction::triggered, this, &MainWindow::importMedia);
 
   // Open camera.
-  AddCameraAction = new QAction(tr("Open &Camera Device..."), this);
+  AddCameraAction = new QAction(tr("Open &Camera Device…"), this);
   AddCameraAction->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_C);
   AddCameraAction->setIcon(QIcon(":/add-camera"));
   AddCameraAction->setIconVisibleInMenu(false);
-  AddCameraAction->setToolTip(tr("Choose your camera device..."));
+  AddCameraAction->setToolTip(tr("Choose your camera device…"));
   AddCameraAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(AddCameraAction);
   connect(AddCameraAction, &QAction::triggered, this, &MainWindow::openCameraDevice);
 
   // Add color.
-  addColorAction = new QAction(tr("Add &Color Source..."), this);
+  addColorAction = new QAction(tr("Add &Color Source…"), this);
   addColorAction->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_A);
   addColorAction->setIcon(QIcon(":/add-color"));
-  addColorAction->setToolTip(tr("Add a color source..."));
+  addColorAction->setToolTip(tr("Add a color source…"));
   addColorAction->setIconVisibleInMenu(false);
   addColorAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addColorAction);
@@ -1887,10 +1887,10 @@ void MainWindow::createActions()
 
 #ifdef Q_OS_MAC
   // Add Syphon source (macOS only).
-  addSyphonAction = new QAction(tr("Add &Syphon Source..."), this);
+  addSyphonAction = new QAction(tr("Add &Syphon Source…"), this);
   addSyphonAction->setShortcut(Qt::CTRL | Qt::SHIFT | Qt::Key_Y);
   addSyphonAction->setIcon(QIcon(":/add-syphon"));
-  addSyphonAction->setToolTip(tr("Receive live video from another application via Syphon..."));
+  addSyphonAction->setToolTip(tr("Receive live video from another application via Syphon…"));
   addSyphonAction->setIconVisibleInMenu(false);
   addSyphonAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addSyphonAction);
@@ -2093,10 +2093,10 @@ void MainWindow::createActions()
   connect(_importLayerMediaAction, &QAction::triggered, this, &MainWindow::loadLayerMedia);
 
   // Preferences...
-  preferencesAction = new QAction(tr("&Preferences..."), this);
+  preferencesAction = new QAction(tr("&Preferences…"), this);
   //preferencesAction->setIcon(QIcon(":/preferences"));
   preferencesAction->setShortcut(Qt::CTRL | Qt::Key_Comma);
-  preferencesAction->setToolTip(tr("Configure preferences..."));
+  preferencesAction->setToolTip(tr("Configure preferences…"));
   //preferencesAction->setIconVisibleInMenu(false);
   preferencesAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(preferencesAction);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -2713,6 +2713,7 @@ void MainWindow::readSettings()
   displayControlsAction->setChecked(settings.value("displayControls", MM::DISPLAY_CONTROLS).toBool());
   outputWindow->setCanvasDisplayCrosshair(settings.value("displayControls", MM::DISPLAY_CONTROLS).toBool());
   oscListeningPort = settings.value("oscListeningPort", MM::DEFAULT_OSC_PORT).toInt();
+  oscAcceptNetwork = settings.value("oscAcceptNetwork", false).toBool();
 #ifdef HAVE_MCP
   mcpListeningPort = settings.value("mcpListeningPort", MM::DEFAULT_MCP_PORT).toInt();
 #endif
@@ -2749,6 +2750,7 @@ void MainWindow::writeSettings()
   settings.setValue("displayControls", displayControlsAction->isChecked());
   settings.setValue("displayAllControls", displaySourceControlsAction->isChecked());
   settings.setValue("oscListeningPort", oscListeningPort);
+  settings.setValue("oscAcceptNetwork", oscAcceptNetwork);
 #ifdef HAVE_MCP
   settings.setValue("mcpListeningPort", mcpListeningPort);
 #endif
@@ -3918,7 +3920,7 @@ void MainWindow::startOscReceiver()
 #else
   QMessageLogger(__FILE__, __LINE__, 0).debug() << "OSC port: " << oscListeningPort;
 #endif
-  osc_interface.reset(new OscInterface(oscListeningPort));
+  osc_interface.reset(new OscInterface(oscListeningPort, oscAcceptNetwork));
   if (oscListeningPort != 0)
   {
     osc_interface->start();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -22,6 +22,7 @@
 #include "MainWindow.h"
 #include "PreferenceDialog.h"
 #include "AboutDialog.h"
+#include "WelcomeDialog.h"
 #include "ShortcutWindow.h"
 #include "Commands.h"
 #include "ProjectWriter.h"
@@ -117,6 +118,10 @@ MainWindow::MainWindow()
 
   // Start playing by default.
   play();
+
+  // Greet the user on first launch (until they opt out from the dialog).
+  if (WelcomeDialog::showOnStartup())
+    QTimer::singleShot(0, this, &MainWindow::showWelcomeDialog);
 }
 
 MainWindow::~MainWindow()
@@ -1787,6 +1792,13 @@ void MainWindow::createLayout()
   setFocus();
 }
 
+void MainWindow::showWelcomeDialog()
+{
+  WelcomeDialog dialog(this);
+  connect(&dialog, &WelcomeDialog::importMediaRequested, this, &MainWindow::importMedia);
+  dialog.exec();
+}
+
 void MainWindow::createActions()
 {
   // New.
@@ -2382,6 +2394,9 @@ void MainWindow::createActions()
   shortcutAction = new QAction(tr("&Keyboard shortcuts"), this);
   shortcutAction->setShortcut(Qt::CTRL | Qt::Key_K);
   connect(shortcutAction, &QAction::triggered, this, &MainWindow::openShortcutWindow);
+  // Welcome / onboarding dialog
+  welcomeAction = new QAction(tr("Welcome to %1…").arg(MM::APPLICATION_NAME), this);
+  connect(welcomeAction, &QAction::triggered, this, &MainWindow::showWelcomeDialog);
 
   // All available screen as action
   updateScreenActions();
@@ -2528,6 +2543,7 @@ void MainWindow::createMenus()
 
   // Help.
   helpMenu = menuBar->addMenu(tr("&Help"));
+  helpMenu->addAction(welcomeAction);
   helpMenu->addAction(docAction);
   helpMenu->addAction(shortcutAction);
   helpMenu->addSeparator();

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3986,7 +3986,8 @@ void MainWindow::startMcpServer()
   quint16 boundPort = mcp_server->start(static_cast<quint16>(mcpListeningPort));
   if (boundPort != 0)
     QMessageLogger(__FILE__, __LINE__, 0).info()
-      << "MCP server listening on http://localhost:" << boundPort << "/mcp";
+      << "MCP server listening on http://localhost:" << boundPort
+      << "/mcp (Authorization: Bearer " << qUtf8Printable(mcp_server->token()) << ")";
   else
     qWarning() << "MCP server could not start on port" << mcpListeningPort;
 }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -107,7 +107,7 @@ MainWindow::MainWindow()
 
   // Create and start timer.
   videoTimer = new QTimer(this);
-  connect(videoTimer, SIGNAL(timeout()), this, SLOT(processFrame()));
+  connect(videoTimer, &QTimer::timeout, this, &MainWindow::processFrame);
   setFramesPerSecond(MM::DEFAULT_FRAMES_PER_SECOND);
   videoTimer->start();
 
@@ -1723,12 +1723,10 @@ void MainWindow::createLayout()
   outputWindow->installEventFilter(destinationCanvas);
 
   // Source scene changed -> change destination.
-  connect(sourceCanvas->scene(), SIGNAL(changed(const QList<QRectF>&)),
-          destinationCanvas,     SLOT(update()));
+  connect(sourceCanvas->scene(), &QGraphicsScene::changed, destinationCanvas, qOverload<>(&QWidget::update));
 
   // Destination scene changed -> change output window.
-  connect(destinationCanvas->scene(), SIGNAL(changed(const QList<QRectF>&)),
-          outputWindow->getCanvas(),  SLOT(update()));
+  connect(destinationCanvas->scene(), &QGraphicsScene::changed, outputWindow->getCanvas(), qOverload<>(&QWidget::update));
 
   // Output changed -> change destinatioin
   // XXX si je decommente cette ligne alors quand je clique sur ajouter media ca gele...
@@ -1765,7 +1763,7 @@ void MainWindow::createLayout()
   mainSplitter = new QSplitter(Qt::Horizontal);
   mainSplitter->addWidget(canvasSplitter);
   mainSplitter->addWidget(contentTab);
-  connect(mainSplitter, SIGNAL(splitterMoved(int, int)), this, SLOT(updateLayerListColumnWidth()));
+  connect(mainSplitter, &QSplitter::splitterMoved, this, &MainWindow::updateLayerListColumnWidth);
 
   // Initialize size to 9:1 proportions.
   QSize sz = mainSplitter->size();
@@ -1799,7 +1797,7 @@ void MainWindow::createActions()
   newAction->setIconVisibleInMenu(false);
   newAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(newAction);
-  connect(newAction, SIGNAL(triggered()), this, SLOT(newFile()));
+  connect(newAction, &QAction::triggered, this, &MainWindow::newFile);
 
   // Open.
   openAction = new QAction(tr("&Open..."), this);
@@ -1809,7 +1807,7 @@ void MainWindow::createActions()
   openAction->setIconVisibleInMenu(false);
   openAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(openAction);
-  connect(openAction, SIGNAL(triggered()), this, SLOT(open()));
+  connect(openAction, &QAction::triggered, this, &MainWindow::open);
 
   // Save.
   saveAction = new QAction(tr("&Save"), this);
@@ -1819,7 +1817,7 @@ void MainWindow::createActions()
   saveAction->setIconVisibleInMenu(false);
   saveAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(saveAction);
-  connect(saveAction, SIGNAL(triggered()), this, SLOT(save()));
+  connect(saveAction, &QAction::triggered, this, &MainWindow::save);
 
   // Save as.
   saveAsAction = new QAction(tr("Save &As..."), this);
@@ -1829,15 +1827,14 @@ void MainWindow::createActions()
   saveAsAction->setIconVisibleInMenu(false);
   saveAsAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(saveAsAction);
-  connect(saveAsAction, SIGNAL(triggered()), this, SLOT(saveAs()));
+  connect(saveAsAction, &QAction::triggered, this, &MainWindow::saveAs);
 
   // Recents file
   for (int i = 0; i < MaxRecentFiles; i++)
   {
     recentFileActions[i] = new QAction(this);
     recentFileActions[i]->setVisible(false);
-    connect(recentFileActions[i], SIGNAL(triggered()),
-            this, SLOT(openRecentFile()));
+    connect(recentFileActions[i], &QAction::triggered, this, &MainWindow::openRecentFile);
   }
 
   // Recent video
@@ -1845,13 +1842,13 @@ void MainWindow::createActions()
   {
     recentVideoActions[i] = new QAction(this);
     recentVideoActions[i]->setVisible(false);
-    connect(recentVideoActions[i], SIGNAL(triggered()), this, SLOT(openRecentVideo()));
+    connect(recentVideoActions[i], &QAction::triggered, this, &MainWindow::openRecentVideo);
   }
 
   // Clear recent video list action
   clearRecentFileActions = new QAction(this);
   clearRecentFileActions->setVisible(true);
-  connect(clearRecentFileActions, SIGNAL(triggered()), this, SLOT(clearRecentFileList()));
+  connect(clearRecentFileActions, &QAction::triggered, this, &MainWindow::clearRecentFileList);
 
   // Empty list of recent video action
   emptyRecentVideos = new QAction(tr("No Recents Videos"), this);
@@ -1866,7 +1863,7 @@ void MainWindow::createActions()
   importMediaAction->setIconVisibleInMenu(false);
   importMediaAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(importMediaAction);
-  connect(importMediaAction, SIGNAL(triggered()), this, SLOT(importMedia()));
+  connect(importMediaAction, &QAction::triggered, this, &MainWindow::importMedia);
 
   // Open camera.
   AddCameraAction = new QAction(tr("Open &Camera Device..."), this);
@@ -1876,7 +1873,7 @@ void MainWindow::createActions()
   AddCameraAction->setToolTip(tr("Choose your camera device..."));
   AddCameraAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(AddCameraAction);
-  connect(AddCameraAction, SIGNAL(triggered()), this, SLOT(openCameraDevice()));
+  connect(AddCameraAction, &QAction::triggered, this, &MainWindow::openCameraDevice);
 
   // Add color.
   addColorAction = new QAction(tr("Add &Color Source..."), this);
@@ -1886,7 +1883,7 @@ void MainWindow::createActions()
   addColorAction->setIconVisibleInMenu(false);
   addColorAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addColorAction);
-  connect(addColorAction, SIGNAL(triggered()), this, SLOT(addColor()));
+  connect(addColorAction, &QAction::triggered, this, &MainWindow::addColor);
 
 #ifdef Q_OS_MAC
   // Add Syphon source (macOS only).
@@ -1897,7 +1894,7 @@ void MainWindow::createActions()
   addSyphonAction->setIconVisibleInMenu(false);
   addSyphonAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addSyphonAction);
-  connect(addSyphonAction, SIGNAL(triggered()), this, SLOT(addSyphon()));
+  connect(addSyphonAction, &QAction::triggered, this, &MainWindow::addSyphon);
 #endif
 
   // Exit/quit.
@@ -1907,7 +1904,7 @@ void MainWindow::createActions()
   exitAction->setIconVisibleInMenu(false);
   exitAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(exitAction);
-  connect(exitAction, SIGNAL(triggered()), this, SLOT(close()));
+  connect(exitAction, &QAction::triggered, this, &QWidget::close);
 
   // Undo action
   undoAction = undoStack->createUndoAction(this, tr("&Undo"));
@@ -1929,7 +1926,7 @@ void MainWindow::createActions()
   aboutAction->setIconVisibleInMenu(false);
   aboutAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(aboutAction);
-  connect(aboutAction, SIGNAL(triggered()), this, SLOT(about()));
+  connect(aboutAction, &QAction::triggered, this, &MainWindow::about);
 
   // Duplicate.
   duplicateLayerAction = new QAction(tr("Duplicate Layer"), this);
@@ -1939,7 +1936,7 @@ void MainWindow::createActions()
   duplicateLayerAction->setEnabled(false);
   duplicateLayerAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(duplicateLayerAction);
-  connect(duplicateLayerAction, SIGNAL(triggered()), this, SLOT(duplicateLayerItem()));
+  connect(duplicateLayerAction, &QAction::triggered, this, &MainWindow::duplicateLayerItem);
 
   // Delete mapping.
   deleteLayerAction = new QAction(tr("Delete Layer"), this);
@@ -1949,7 +1946,7 @@ void MainWindow::createActions()
   deleteLayerAction->setEnabled(false);
   deleteLayerAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(deleteLayerAction);
-  connect(deleteLayerAction, SIGNAL(triggered()), this, SLOT(deleteLayerItem()));
+  connect(deleteLayerAction, &QAction::triggered, this, &MainWindow::deleteLayerItem);
 
   // Rename mapping.
   renameLayerAction = new QAction(tr("Rename Layer"), this);
@@ -1959,7 +1956,7 @@ void MainWindow::createActions()
   renameLayerAction->setEnabled(false);
   renameLayerAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(renameLayerAction);
-  connect(renameLayerAction, SIGNAL(triggered()), this, SLOT(renameLayerItem()));
+  connect(renameLayerAction, &QAction::triggered, this, &MainWindow::renameLayerItem);
 
   // Lock mapping.
   layerLockedAction = new QAction(tr("Lock Layer"), this);
@@ -1970,7 +1967,7 @@ void MainWindow::createActions()
   layerLockedAction->setEnabled(false);
   layerLockedAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(layerLockedAction);
-  connect(layerLockedAction, SIGNAL(triggered(bool)), this, SLOT(setLayerItemLocked(bool)));
+  connect(layerLockedAction, &QAction::triggered, this, &MainWindow::setLayerItemLocked);
 
   // Hide mapping.
   layerHideAction = new QAction(tr("Hide Layer"), this);
@@ -1981,7 +1978,7 @@ void MainWindow::createActions()
   layerHideAction->setEnabled(false);
   layerHideAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(layerHideAction);
-  connect(layerHideAction, SIGNAL(triggered(bool)), this, SLOT(setLayerItemHide(bool)));
+  connect(layerHideAction, &QAction::triggered, this, &MainWindow::setLayerItemHide);
 
   // Solo mapping.
   layerSoloAction = new QAction(tr("Solo Layer"), this);
@@ -1992,7 +1989,7 @@ void MainWindow::createActions()
   layerSoloAction->setEnabled(false);
   layerSoloAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(layerSoloAction);
-  connect(layerSoloAction, SIGNAL(triggered(bool)), this, SLOT(setLayerItemSolo(bool)));
+  connect(layerSoloAction, &QAction::triggered, this, &MainWindow::setLayerItemSolo);
 
   // Rotate 90 degrees CW action.
   layerRotate90CWAction = new QAction(tr("Rotate 90° CW"), this);
@@ -2000,7 +1997,7 @@ void MainWindow::createActions()
   layerRotate90CWAction->setIconVisibleInMenu(true);
   layerRotate90CWAction->setEnabled(false);
   addAction(layerRotate90CWAction);
-  connect(layerRotate90CWAction, SIGNAL(triggered()), SLOT(transformActionLayerItem()));
+  connect(layerRotate90CWAction, &QAction::triggered, this, &MainWindow::transformActionLayerItem);
 
   // Rotate 90 degrees CW action.
   layerRotate90CCWAction = new QAction(tr("Rotate 90° CW"), this);
@@ -2008,7 +2005,7 @@ void MainWindow::createActions()
   layerRotate90CCWAction->setIconVisibleInMenu(true);
   layerRotate90CCWAction->setEnabled(false);
   addAction(layerRotate90CCWAction);
-  connect(layerRotate90CCWAction, SIGNAL(triggered()), SLOT(transformActionLayerItem()));
+  connect(layerRotate90CCWAction, &QAction::triggered, this, &MainWindow::transformActionLayerItem);
 
   // Rotate 180 degrees action.
   layerRotate180Action = new QAction(tr("Rotate 180°"), this);
@@ -2016,7 +2013,7 @@ void MainWindow::createActions()
   layerRotate180Action->setIconVisibleInMenu(true);
   layerRotate180Action->setEnabled(false);
   addAction(layerRotate180Action);
-  connect(layerRotate180Action, SIGNAL(triggered()), SLOT(transformActionLayerItem()));
+  connect(layerRotate180Action, &QAction::triggered, this, &MainWindow::transformActionLayerItem);
 
   // Horizontal Flip Action
   layerHorizontalFlipAction = new QAction(tr("Flip Horizontally"), this);
@@ -2025,7 +2022,7 @@ void MainWindow::createActions()
   layerHorizontalFlipAction->setIconVisibleInMenu(true);
   layerHorizontalFlipAction->setEnabled(false);
   addAction(layerHorizontalFlipAction);
-  connect(layerHorizontalFlipAction, SIGNAL(triggered()), SLOT(transformActionLayerItem()));
+  connect(layerHorizontalFlipAction, &QAction::triggered, this, &MainWindow::transformActionLayerItem);
 
   // Vertical Flip Action
   layerVerticalFlipAction = new QAction(tr("Flip Vertically"), this);
@@ -2034,7 +2031,7 @@ void MainWindow::createActions()
   layerVerticalFlipAction->setIconVisibleInMenu(true);
   layerVerticalFlipAction->setEnabled(false);
   addAction(layerVerticalFlipAction);
-  connect(layerVerticalFlipAction, SIGNAL(triggered()), SLOT(transformActionLayerItem()));
+  connect(layerVerticalFlipAction, &QAction::triggered, this, &MainWindow::transformActionLayerItem);
 
   layerRaiseAction = new QAction(tr("Raise"), this);
   layerRaiseAction->setShortcut(Qt::Key_PageUp);
@@ -2042,7 +2039,7 @@ void MainWindow::createActions()
   layerRaiseAction->setIconVisibleInMenu(true);
   layerRaiseAction->setEnabled(false);
   addAction(layerRaiseAction);
-  connect(layerRaiseAction, SIGNAL(triggered()), SLOT(reorderLayerItem()));
+  connect(layerRaiseAction, &QAction::triggered, this, &MainWindow::reorderLayerItem);
 
   layerLowerAction = new QAction(tr("Lower"), this);
   layerLowerAction->setShortcut(Qt::Key_PageDown);
@@ -2050,7 +2047,7 @@ void MainWindow::createActions()
   layerLowerAction->setIconVisibleInMenu(true);
   layerLowerAction->setEnabled(false);
   addAction(layerLowerAction);
-  connect(layerLowerAction, SIGNAL(triggered()), SLOT(reorderLayerItem()));
+  connect(layerLowerAction, &QAction::triggered, this, &MainWindow::reorderLayerItem);
 
   layerRaiseToTopAction = new QAction(tr("Raise to Top"), this);
   layerRaiseToTopAction->setShortcut(Qt::Key_Home); // bottom = end
@@ -2058,7 +2055,7 @@ void MainWindow::createActions()
   layerRaiseToTopAction->setIconVisibleInMenu(true);
   layerRaiseToTopAction->setEnabled(false);
   addAction(layerRaiseToTopAction);
-  connect(layerRaiseToTopAction, SIGNAL(triggered()), SLOT(reorderLayerItem()));
+  connect(layerRaiseToTopAction, &QAction::triggered, this, &MainWindow::reorderLayerItem);
 
   layerLowerToBottomAction = new QAction(tr("Lower to Bottom"), this);
   layerLowerToBottomAction->setShortcut(Qt::Key_End);
@@ -2066,7 +2063,7 @@ void MainWindow::createActions()
   layerLowerToBottomAction->setIconVisibleInMenu(true);
   layerLowerToBottomAction->setEnabled(false);
   addAction(layerLowerToBottomAction);
-  connect(layerLowerToBottomAction, SIGNAL(triggered()), SLOT(reorderLayerItem()));
+  connect(layerLowerToBottomAction, &QAction::triggered, this, &MainWindow::reorderLayerItem);
 
   // Delete source.
   deleteSourceAction = new QAction(tr("Delete Source"), this);
@@ -2076,7 +2073,7 @@ void MainWindow::createActions()
   deleteSourceAction->setEnabled(false);
   deleteSourceAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(deleteSourceAction);
-  connect(deleteSourceAction, SIGNAL(triggered()), this, SLOT(deleteSourceItem()));
+  connect(deleteSourceAction, &QAction::triggered, this, &MainWindow::deleteSourceItem);
 
   // Rename source.
   renameSourceAction = new QAction(tr("Rename Source"), this);
@@ -2086,14 +2083,14 @@ void MainWindow::createActions()
   renameSourceAction->setEnabled(false);
   renameSourceAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(renameSourceAction);
-  connect(renameSourceAction, SIGNAL(triggered()), this, SLOT(renameSourceItem()));
+  connect(renameSourceAction, &QAction::triggered, this, &MainWindow::renameSourceItem);
 
   // Import a new media for current layer
   _importLayerMediaAction = new QAction(tr("Import New Media"), this);
   _importLayerMediaAction->setToolTip(tr("Import new media file if not exists on the list"));
   _importLayerMediaAction->setIconVisibleInMenu(false);
   _importLayerMediaAction->setData("import-new-media"); // Important
-  connect(_importLayerMediaAction, SIGNAL(triggered()), this, SLOT(loadLayerMedia()));
+  connect(_importLayerMediaAction, &QAction::triggered, this, &MainWindow::loadLayerMedia);
 
   // Preferences...
   preferencesAction = new QAction(tr("&Preferences..."), this);
@@ -2103,6 +2100,8 @@ void MainWindow::createActions()
   //preferencesAction->setIconVisibleInMenu(false);
   preferencesAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(preferencesAction);
+  // exec() is a private custom override of PreferenceDialog, reachable only via
+  // the string-based connection.
   connect(preferencesAction, SIGNAL(triggered()), _preferenceDialog, SLOT(exec()));
 
   // Add mesh.
@@ -2113,7 +2112,7 @@ void MainWindow::createActions()
   addMeshAction->setIconVisibleInMenu(false);
   addMeshAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addMeshAction);
-  connect(addMeshAction, SIGNAL(triggered()), this, SLOT(addMesh()));
+  connect(addMeshAction, &QAction::triggered, this, &MainWindow::addMesh);
   addMeshAction->setEnabled(false);
 
   // Add triangle.
@@ -2124,7 +2123,7 @@ void MainWindow::createActions()
   addTriangleAction->setIconVisibleInMenu(false);
   addTriangleAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addTriangleAction);
-  connect(addTriangleAction, SIGNAL(triggered()), this, SLOT(addTriangle()));
+  connect(addTriangleAction, &QAction::triggered, this, &MainWindow::addTriangle);
   addTriangleAction->setEnabled(false);
 
   // Add ellipse.
@@ -2135,7 +2134,7 @@ void MainWindow::createActions()
   addEllipseAction->setIconVisibleInMenu(false);
   addEllipseAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(addEllipseAction);
-  connect(addEllipseAction, SIGNAL(triggered()), this, SLOT(addEllipse()));
+  connect(addEllipseAction, &QAction::triggered, this, &MainWindow::addEllipse);
   addEllipseAction->setEnabled(false);
 
   // Play.
@@ -2147,7 +2146,7 @@ void MainWindow::createActions()
   playAction->setIconVisibleInMenu(false);
   playAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(playAction);
-  connect(playAction, SIGNAL(triggered()), this, SLOT(play()));
+  connect(playAction, &QAction::triggered, this, &MainWindow::play);
   playAction->setVisible(true);
 
   // Pause.
@@ -2158,7 +2157,7 @@ void MainWindow::createActions()
   pauseAction->setIconVisibleInMenu(false);
   pauseAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(pauseAction);
-  connect(pauseAction, SIGNAL(triggered()), this, SLOT(pause()));
+  connect(pauseAction, &QAction::triggered, this, &MainWindow::pause);
   pauseAction->setVisible(false);
 
   // Rewind.
@@ -2169,7 +2168,7 @@ void MainWindow::createActions()
   rewindAction->setIconVisibleInMenu(false);
   rewindAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(rewindAction);
-  connect(rewindAction, SIGNAL(triggered()), this, SLOT(rewind()));
+  connect(rewindAction, &QAction::triggered, this, &MainWindow::rewind);
 
   // Toggle display of output window.
   outputFullScreenAction = new QAction(tr("Toggle &Fullscreen"), this);
@@ -2183,7 +2182,7 @@ void MainWindow::createActions()
   outputFullScreenAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(outputFullScreenAction);
   // Manage fullscreen/modal show of GL output window.
-  connect(outputFullScreenAction, SIGNAL(toggled(bool)), outputWindow, SLOT(setFullScreen(bool)));
+  connect(outputFullScreenAction, &QAction::toggled, outputWindow, &OutputGLWindow::setFullScreen);
   connect(qApp, &QGuiApplication::screenAdded,   this, [this](QScreen*){ updateScreenCount(); });
   connect(qApp, &QGuiApplication::screenRemoved,  this, [this](QScreen*){ updateScreenCount(); });
   // Create hiden action for closing output window
@@ -2191,7 +2190,7 @@ void MainWindow::createActions()
   closeOutput->setShortcut(Qt::Key_Escape);
   closeOutput->setShortcutContext(Qt::ApplicationShortcut);
   addAction(closeOutput);
-  connect(closeOutput, SIGNAL(triggered(bool)), this, SLOT(exitFullScreen()));
+  connect(closeOutput, &QAction::triggered, this, &MainWindow::exitFullScreen);
 
   // Toggle display of canvas controls.
   displayControlsAction = new QAction(tr("&Display Controls"), this);
@@ -2204,8 +2203,8 @@ void MainWindow::createActions()
   displayControlsAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(displayControlsAction);
   // Manage show/hide of canvas controls.
-  connect(displayControlsAction, SIGNAL(toggled(bool)), this, SLOT(enableDisplayControls(bool)));
-  connect(displayControlsAction, SIGNAL(toggled(bool)), outputWindow, SLOT(setCanvasDisplayCrosshair(bool)));
+  connect(displayControlsAction, &QAction::toggled, this, &MainWindow::enableDisplayControls);
+  connect(displayControlsAction, &QAction::toggled, outputWindow, &OutputGLWindow::setCanvasDisplayCrosshair);
 
   // Toggle display of canvas controls.
   displaySourceControlsAction = new QAction(tr("&Display Controls of Layers of a Source"), this);
@@ -2218,9 +2217,9 @@ void MainWindow::createActions()
   displaySourceControlsAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(displaySourceControlsAction);
   // Manage show/hide of canvas controls.
-  connect(displaySourceControlsAction, SIGNAL(toggled(bool)), this, SLOT(enableDisplaySourceControls(bool)));
+  connect(displaySourceControlsAction, &QAction::toggled, this, &MainWindow::enableDisplaySourceControls);
 //  connect(displaySourceControlsAction, SIGNAL(toggled(bool)), outputWindow, SLOT(setDisplayCrosshair(bool)));
-  connect(displayControlsAction, SIGNAL(toggled(bool)), displaySourceControlsAction, SLOT(setEnabled(bool)));
+  connect(displayControlsAction, &QAction::toggled, displaySourceControlsAction, &QAction::setEnabled);
 
   // Toggle sticky vertices
   stickyVerticesAction = new QAction(tr("&Sticky Vertices"), this);
@@ -2233,7 +2232,7 @@ void MainWindow::createActions()
   stickyVerticesAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(stickyVerticesAction);
   // Manage sticky vertices
-  connect(stickyVerticesAction, SIGNAL(toggled(bool)), this, SLOT(enableStickyVertices(bool)));
+  connect(stickyVerticesAction, &QAction::toggled, this, &MainWindow::enableStickyVertices);
 
   displayTestSignalAction = new QAction(tr("Show &Test Signal"), this);
   displayTestSignalAction->setShortcut(Qt::ALT | Qt::Key_T);
@@ -2245,7 +2244,7 @@ void MainWindow::createActions()
   displayTestSignalAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(displayTestSignalAction);
   // Manage show/hide of test signal
-  connect(displayTestSignalAction, SIGNAL(toggled(bool)), outputWindow, SLOT(setDisplayTestSignal(bool)));
+  connect(displayTestSignalAction, &QAction::toggled, outputWindow, &OutputGLWindow::setDisplayTestSignal);
 //  connect(displayTestSignalAction, SIGNAL(toggled(bool)), this, SLOT(update()));
 
 #if defined(HAVE_SYPHON) && defined(SYPHON_OUTPUT_EXPERIMENTAL)
@@ -2258,7 +2257,7 @@ void MainWindow::createActions()
   publishSyphonOutputAction->setChecked(false);
   publishSyphonOutputAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(publishSyphonOutputAction);
-  connect(publishSyphonOutputAction, SIGNAL(toggled(bool)), outputWindow, SLOT(setSyphonOutputEnabled(bool)));
+  connect(publishSyphonOutputAction, &QAction::toggled, outputWindow, &OutputGLWindow::setSyphonOutputEnabled);
   connect(publishSyphonOutputAction, &QAction::toggled, this, [](bool on) {
     QSettings s; s.setValue("publishSyphonOutput", on);
   });
@@ -2274,7 +2273,7 @@ void MainWindow::createActions()
   displayUndoHistoryAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(displayUndoHistoryAction);
   // Manage show/hide of Undo History
-  connect(displayUndoHistoryAction, SIGNAL(toggled(bool)), this, SLOT(displayUndoHistory(bool)));
+  connect(displayUndoHistoryAction, &QAction::toggled, this, &MainWindow::displayUndoHistory);
 
   // Toggle display of Console output
   openConsoleAction = new QAction(tr("Open Conso&le"), this);
@@ -2283,9 +2282,9 @@ void MainWindow::createActions()
   openConsoleAction->setChecked(false);
   openConsoleAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(openConsoleAction);
-  connect(openConsoleAction, SIGNAL(toggled(bool)), consoleWindow, SLOT(setVisible(bool)));
+  connect(openConsoleAction, &QAction::toggled, consoleWindow, &ConsoleWindow::setVisible);
   // uncheck action when window is closed
-  connect(consoleWindow, SIGNAL(windowClosed()), openConsoleAction, SLOT(toggle()));
+  connect(consoleWindow, &ConsoleWindow::windowClosed, openConsoleAction, &QAction::toggle);
 
   // Toggle display of zoom tool buttons
   displayZoomToolAction = new QAction(tr("Display &Zoom Toolbar"), this);
@@ -2294,14 +2293,14 @@ void MainWindow::createActions()
   displayZoomToolAction->setChecked(true);
   displayZoomToolAction->setShortcutContext(Qt::ApplicationShortcut);
   addAction(displayZoomToolAction);
-  connect(displayZoomToolAction, SIGNAL(toggled(bool)), sourceCanvasToolbar, SLOT(showZoomToolBar(bool)));
-  connect(displayZoomToolAction, SIGNAL(toggled(bool)), destinationCanvasToolbar, SLOT(showZoomToolBar(bool)));
+  connect(displayZoomToolAction, &QAction::toggled, sourceCanvasToolbar, &MapperGLCanvasToolbar::showZoomToolBar);
+  connect(displayZoomToolAction, &QAction::toggled, destinationCanvasToolbar, &MapperGLCanvasToolbar::showZoomToolBar);
 
   // Toggle show/hide menuBar
   showMenuBarAction = new QAction(tr("&Menu Bar"), this);
   showMenuBarAction->setCheckable(true);
   showMenuBarAction->setChecked(_showMenuBar);
-  connect(showMenuBarAction, SIGNAL(toggled(bool)), this, SLOT(showMenuBar(bool)));
+  connect(showMenuBarAction, &QAction::toggled, this, &MainWindow::showMenuBar);
 
   // Perspectives
   // Main perspective (Source + destination)
@@ -2310,22 +2309,22 @@ void MainWindow::createActions()
   mainViewAction->setChecked(true);
   mainViewAction->setShortcut(Qt::CTRL | Qt::Key_1);
   mainViewAction->setToolTip(tr("Switch to the Main layout."));
-  connect(mainViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(0), SLOT(setVisible(bool)));
-  connect(mainViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(1), SLOT(setVisible(bool)));
+  connect(mainViewAction, &QAction::triggered, canvasSplitter->widget(0), &QWidget::setVisible);
+  connect(mainViewAction, &QAction::triggered, canvasSplitter->widget(1), &QWidget::setVisible);
   // Source Only
   sourceViewAction = new QAction(tr("Input editor Layout"), this);
   sourceViewAction->setCheckable(true);
   sourceViewAction->setShortcut(Qt::CTRL | Qt::Key_2);
   sourceViewAction->setToolTip(tr("Switch to the Input editor Layout."));
-  connect(sourceViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(0), SLOT(setVisible(bool)));
-  connect(sourceViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(1), SLOT(setHidden(bool)));
+  connect(sourceViewAction, &QAction::triggered, canvasSplitter->widget(0), &QWidget::setVisible);
+  connect(sourceViewAction, &QAction::triggered, canvasSplitter->widget(1), &QWidget::setHidden);
   // Destination Only
   destViewAction = new QAction(tr("Output Editor Layout"), this);
   destViewAction->setCheckable(true);
   destViewAction->setShortcut(Qt::CTRL | Qt::Key_3);
   destViewAction->setToolTip(tr("Switch to the Output Editors Layout."));
-  connect(destViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(0), SLOT(setHidden(bool)));
-  connect(destViewAction, SIGNAL(triggered(bool)), canvasSplitter->widget(1), SLOT(setVisible(bool)));
+  connect(destViewAction, &QAction::triggered, canvasSplitter->widget(0), &QWidget::setHidden);
+  connect(destViewAction, &QAction::triggered, canvasSplitter->widget(1), &QWidget::setVisible);
   // Groups all actions
   perspectiveActionGroup = new QActionGroup(this);
   perspectiveActionGroup->addAction(mainViewAction);
@@ -2338,51 +2337,51 @@ void MainWindow::createActions()
   zoomInAction->setShortcut(QKeySequence::ZoomIn);
   zoomInAction->setToolTip(tr("Zoom In"));
   zoomInAction->setEnabled(false);
-  connect(zoomInAction, SIGNAL(triggered()), sourceCanvas, SLOT(increaseZoomLevel()));
-  connect(zoomInAction, SIGNAL(triggered()), destinationCanvas, SLOT(increaseZoomLevel()));
+  connect(zoomInAction, &QAction::triggered, sourceCanvas, &MapperGLCanvas::increaseZoomLevel);
+  connect(zoomInAction, &QAction::triggered, destinationCanvas, &MapperGLCanvas::increaseZoomLevel);
   // Zoom Out
   zoomOutAction = new QAction(tr("Zoom Out"), this);
   zoomOutAction->setShortcut(QKeySequence::ZoomOut);
   zoomOutAction->setToolTip(tr("Zoom Out"));
   zoomOutAction->setEnabled(false);
-  connect(zoomOutAction, SIGNAL(triggered()), sourceCanvas, SLOT(decreaseZoomLevel()));
-  connect(zoomOutAction, SIGNAL(triggered()), destinationCanvas, SLOT(decreaseZoomLevel()));
+  connect(zoomOutAction, &QAction::triggered, sourceCanvas, &MapperGLCanvas::decreaseZoomLevel);
+  connect(zoomOutAction, &QAction::triggered, destinationCanvas, &MapperGLCanvas::decreaseZoomLevel);
   // Reset zoom
   resetZoomAction = new QAction(tr("Original Size"), this);
   resetZoomAction->setShortcut(Qt::CTRL | Qt::Key_0);
   resetZoomAction->setToolTip(tr("Reset zoom to original size"));
   resetZoomAction->setEnabled(false);
-  connect(resetZoomAction, SIGNAL(triggered()), sourceCanvas, SLOT(resetZoomLevel()));
-  connect(resetZoomAction, SIGNAL(triggered()), destinationCanvas, SLOT(resetZoomLevel()));
+  connect(resetZoomAction, &QAction::triggered, sourceCanvas, &MapperGLCanvas::resetZoomLevel);
+  connect(resetZoomAction, &QAction::triggered, destinationCanvas, &MapperGLCanvas::resetZoomLevel);
   // Fit to view
   fitToViewAction = new QAction(tr("Fit To View"), this);
   fitToViewAction->setToolTip(tr("Fit to viewport"));
   fitToViewAction->setEnabled(false);
-  connect(fitToViewAction, SIGNAL(triggered()), sourceCanvas, SLOT(fitShapeToView()));
-  connect(fitToViewAction, SIGNAL(triggered()), destinationCanvas, SLOT(fitShapeToView()));
+  connect(fitToViewAction, &QAction::triggered, sourceCanvas, &MapperGLCanvas::fitShapeToView);
+  connect(fitToViewAction, &QAction::triggered, destinationCanvas, &MapperGLCanvas::fitShapeToView);
 
   // Helps
   // Bug report
   bugReportAction = new QAction(tr("Report an issue"), this);
-  connect(bugReportAction, SIGNAL(triggered()), this, SLOT(reportBug()));
+  connect(bugReportAction, &QAction::triggered, this, &MainWindow::reportBug);
   // Professional services & custom development by Art Plus Code (sponsor).
   servicesAction = new QAction(tr("Professional services && custom development…"), this);
   servicesAction->setToolTip(tr("Hire Art Plus Code for video mapping installations, custom features, integration and training"));
-  connect(servicesAction, SIGNAL(triggered()), this, SLOT(professionalServices()));
+  connect(servicesAction, &QAction::triggered, this, &MainWindow::professionalServices);
   // Support the project (donations, consolidated on Open Collective).
   donateAction = new QAction(tr("Support the project (donate)…"), this);
   donateAction->setToolTip(tr("Help fund MapMap's ongoing development"));
-  connect(donateAction, SIGNAL(triggered()), this, SLOT(donate()));
+  connect(donateAction, &QAction::triggered, this, &MainWindow::donate);
   // Documentation
   docAction = new QAction(tr("Documentation"), this);
-  connect(docAction, SIGNAL(triggered()), this, SLOT(documentation()));
+  connect(docAction, &QAction::triggered, this, &MainWindow::documentation);
   // Send us feedback
   feedbackAction = new QAction(tr("Submit feedback via email"), this);
-  connect(feedbackAction, SIGNAL(triggered()), this, SLOT(sendFeedback()));
+  connect(feedbackAction, &QAction::triggered, this, &MainWindow::sendFeedback);
   // Keyboard shortcuts
   shortcutAction = new QAction(tr("&Keyboard shortcuts"), this);
   shortcutAction->setShortcut(Qt::CTRL | Qt::Key_K);
-  connect(shortcutAction, SIGNAL(triggered()), this, SLOT(openShortcutWindow()));
+  connect(shortcutAction, &QAction::triggered, this, &MainWindow::openShortcutWindow);
 
   // All available screen as action
   updateScreenActions();
@@ -2584,10 +2583,9 @@ void MainWindow::createLayerContextMenu()
   outputWindow->setContextMenuPolicy(Qt::CustomContextMenu);
 
   // Context Menu Connexions
-  connect(layerItemDelegate, SIGNAL(itemContextMenuRequested(const QPoint&)),
-          this, SLOT(showLayerContextMenu(const QPoint&)), Qt::QueuedConnection);
-  connect(destinationCanvas, SIGNAL(shapeContextMenuRequested(const QPoint&)), this, SLOT(showLayerContextMenu(const QPoint&)));
-  connect(outputWindow->getCanvas(), SIGNAL(shapeContextMenuRequested(const QPoint&)), this, SLOT(showLayerContextMenu(const QPoint&)));
+  connect(layerItemDelegate, &LayerItemDelegate::itemContextMenuRequested, this, &MainWindow::showLayerContextMenu, Qt::QueuedConnection);
+  connect(destinationCanvas, &MapperGLCanvas::shapeContextMenuRequested, this, &MainWindow::showLayerContextMenu);
+  connect(outputWindow->getCanvas(), &MapperGLCanvas::shapeContextMenuRequested, this, &MainWindow::showLayerContextMenu);
 }
 
 void MainWindow::createSourceContextMenu()
@@ -2605,8 +2603,8 @@ void MainWindow::createSourceContextMenu()
   sourceCanvas->setContextMenuPolicy(Qt::CustomContextMenu);
 
   // Connexions
-  connect(sourceList, SIGNAL(customContextMenuRequested(const QPoint&)), this, SLOT(showSourceContextMenu(const QPoint&)));
-  connect(sourceCanvas, SIGNAL(shapeContextMenuRequested(const QPoint&)), this, SLOT(showSourceContextMenu(const QPoint&)));
+  connect(sourceList, &QListWidget::customContextMenuRequested, this, &MainWindow::showSourceContextMenu);
+  connect(sourceCanvas, &MapperGLCanvas::shapeContextMenuRequested, this, &MainWindow::showSourceContextMenu);
 }
 
 void MainWindow::createToolBars()
@@ -2973,7 +2971,7 @@ void MainWindow::updateScreenActions()
     if (action == screenActions.at(preferredScreen)) {
       action->setChecked(true);
     }
-    connect(action, SIGNAL(triggered()), this, SLOT(setupOutputScreen()));
+    connect(action, &QAction::triggered, this, &MainWindow::setupOutputScreen);
     screenActionGroup->addAction(action);
   }
 }
@@ -2989,8 +2987,7 @@ void MainWindow::updateMediaListActions()
       mediaAction->setText(tr("&%1 %2").arg(i + 1).arg(mappingManager->getSource(i)->getName()));
       mediaAction->setData(mappingManager->getSource(i)->getId());
       mediaAction->setVisible(true);
-      connect(mediaAction, SIGNAL(triggered()),
-              this, SLOT(loadLayerMedia()));
+      connect(mediaAction, &QAction::triggered, this, &MainWindow::loadLayerMedia);
       // Add new media on action list
       _changeLayerMediaMenu->addAction(mediaAction);
     }
@@ -3149,25 +3146,19 @@ void MainWindow::addSourceItem(uid sourceId, const QIcon& icon, const QString& n
   //  connect(sourceGui.get(), SIGNAL(valueChanged()),
   //          this,           SLOT(updateCanvases()));
 
-  connect(sourceGui.data(), SIGNAL(valueChanged(Source::ptr)),
-          this,            SLOT(handleSourceChanged(Source::ptr)));
+  connect(sourceGui.data(), &SourceGui::valueChanged, this, &MainWindow::handleSourceChanged);
 
-  connect(source.data(), SIGNAL(propertyChanged(uid, QString, QVariant)),
-          this,           SLOT(sourcePropertyChanged(uid, QString, QVariant)));
+  connect(source.data(), &Source::propertyChanged, this, &MainWindow::sourcePropertyChanged);
 
   // TODO: attention: if mapping is invisible canvases will be updated for no reason
-  connect(source.data(), SIGNAL(propertyChanged(uid, QString, QVariant)),
-          this,           SLOT(updateCanvases()));
+  connect(source.data(), &Source::propertyChanged, this, &MainWindow::updateCanvases);
 
 #ifdef HAVE_SYPHON
   // Fit input shapes once a Syphon source's real resolution becomes known.
   // Queued so the shapes are not mutated mid-paint (the signal fires while
   // rendering the source).
   if (sourceType == SourceType::Syphon)
-    connect(qSharedPointerCast<Syphon>(source).data(),
-            SIGNAL(frameSizeKnown(int, int, int)),
-            this, SLOT(autoFitSyphonInputShapes(int, int, int)),
-            Qt::QueuedConnection);
+    connect(qSharedPointerCast<Syphon>(source).data(), &Syphon::frameSizeKnown, this, &MainWindow::autoFitSyphonInputShapes, Qt::QueuedConnection);
 #endif
 
   // Add source item to sourceList widget.
@@ -3291,25 +3282,19 @@ void MainWindow::addLayerItem(uid layerId)
   layerPropertyPanel->setEnabled(true);
 
   // When mapper value is changed, update canvases.
-  connect(mapper.data(), SIGNAL(valueChanged()),
-          this,          SLOT(updateCanvases()));
+  connect(mapper.data(), &LayerGui::valueChanged, this, &MainWindow::updateCanvases);
 
   // Also update playing state in case source was changed.
-  connect(mapper.data(), SIGNAL(sourceChanged()),
-          this,          SLOT(updatePlayingState()));
+  connect(mapper.data(), &LayerGui::sourceChanged, this, &MainWindow::updatePlayingState);
 
-  connect(sourceCanvas,  SIGNAL(shapeChanged(MShape*)),
-          mapper.data(), SLOT(updateShape(MShape*)));
+  connect(sourceCanvas, &MapperGLCanvas::shapeChanged, mapper.data(), &LayerGui::updateShape);
 
-  connect(destinationCanvas, SIGNAL(shapeChanged(MShape*)),
-          mapper.data(),     SLOT(updateShape(MShape*)));
+  connect(destinationCanvas, &MapperGLCanvas::shapeChanged, mapper.data(), &LayerGui::updateShape);
 
-  connect(layer.data(), SIGNAL(propertyChanged(uid, QString, QVariant)),
-          this,           SLOT(layerPropertyChanged(uid, QString, QVariant)));
+  connect(layer.data(), &Layer::propertyChanged, this, &MainWindow::layerPropertyChanged);
 
   // TODO: attention: if mapping is invisible canvases will be updated for no reason
-  connect(layer.data(), SIGNAL(propertyChanged(uid, QString, QVariant)),
-          this,           SLOT(updateCanvases()));
+  connect(layer.data(), &Layer::propertyChanged, this, &MainWindow::updateCanvases);
 
   // Switch to mapping tab.
   contentTab->setCurrentWidget(layerSplitter);
@@ -3759,66 +3744,48 @@ const QIcon MainWindow::getSourceIcon(Source::ptr source)
 
 void MainWindow::connectProjectWidgets()
 {
-  connect(sourceList, SIGNAL(itemSelectionChanged()),
-          this,      SLOT(handleSourceItemSelectionChanged()));
+  connect(sourceList, &QListWidget::itemSelectionChanged, this, &MainWindow::handleSourceItemSelectionChanged);
 
-  connect(sourceList, SIGNAL(itemPressed(QListWidgetItem*)),
-          this,      SLOT(handleSourceItemSelected(QListWidgetItem*)));
+  connect(sourceList, &QListWidget::itemPressed, this, &MainWindow::handleSourceItemSelected);
 
-  connect(sourceList, SIGNAL(itemActivated(QListWidgetItem*)),
-          this,      SLOT(handleSourceItemSelected(QListWidgetItem*)));
+  connect(sourceList, &QListWidget::itemActivated, this, &MainWindow::handleSourceItemSelected);
   // Rename Source with double click
-  connect(sourceList, SIGNAL(itemDoubleClicked(QListWidgetItem*)),
-          this,      SLOT(renameSourceItem()));
+  connect(sourceList, &QListWidget::itemDoubleClicked, this, &MainWindow::renameSourceItem);
   // When finish to edit mapping item
-  connect(sourceList->itemDelegate(), SIGNAL(commitData(QWidget*)),
-          this, SLOT(sourceListEditEnd(QWidget*)));
+  connect(sourceList->itemDelegate(), &QAbstractItemDelegate::commitData, this, &MainWindow::sourceListEditEnd);
 
-  connect(layerList->selectionModel(), SIGNAL(currentRowChanged(QModelIndex,QModelIndex)),
-          this,        SLOT(handleLayerItemSelectionChanged(QModelIndex)));
+  connect(layerList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &MainWindow::handleLayerItemSelectionChanged);
 
-  connect(layerListModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)),
-          this,        SLOT(handleLayerItemChanged(QModelIndex)));
+  connect(layerListModel, &LayerListModel::dataChanged, this, &MainWindow::handleLayerItemChanged);
 
-  connect(layerListModel, SIGNAL(rowsMoved(QModelIndex,int,int,QModelIndex,int)),
-          this,                 SLOT(handleLayerIndexesMoved()));
+  connect(layerListModel, &LayerListModel::rowsMoved, this, &MainWindow::handleLayerIndexesMoved);
 
-  connect(layerItemDelegate, SIGNAL(itemDuplicated(uid)),
-          this, SLOT(duplicateLayer(uid)));
+  connect(layerItemDelegate, &LayerItemDelegate::itemDuplicated, this, &MainWindow::duplicateLayer);
 
-  connect(layerItemDelegate, SIGNAL(itemRemoved(uid)),
-          this, SLOT(deleteLayer(uid)));
+  connect(layerItemDelegate, &LayerItemDelegate::itemRemoved, this, &MainWindow::deleteLayer);
 
-  connect(_preferenceDialog, SIGNAL(settingSaved()), this, SLOT(updateSettings()));
+  connect(_preferenceDialog, &PreferenceDialog::settingSaved, this, &MainWindow::updateSettings);
 }
 
 void MainWindow::disconnectProjectWidgets()
 {
-  disconnect(sourceList, SIGNAL(itemSelectionChanged()),
-             this,      SLOT(handleSourceItemSelectionChanged()));
+  disconnect(sourceList, &QListWidget::itemSelectionChanged, this, &MainWindow::handleSourceItemSelectionChanged);
 
-  disconnect(sourceList, SIGNAL(itemPressed(QListWidgetItem*)),
-             this,      SLOT(handleSourceItemSelected(QListWidgetItem*)));
+  disconnect(sourceList, &QListWidget::itemPressed, this, &MainWindow::handleSourceItemSelected);
 
-  disconnect(sourceList, SIGNAL(itemActivated(QListWidgetItem*)),
-             this,      SLOT(handleSourceItemSelected(QListWidgetItem*)));
+  disconnect(sourceList, &QListWidget::itemActivated, this, &MainWindow::handleSourceItemSelected);
 
-  disconnect(layerList->selectionModel(), SIGNAL(currentRowChanged(QModelIndex,QModelIndex)),
-          this,        SLOT(handleLayerItemSelectionChanged(QModelIndex)));
+  disconnect(layerList->selectionModel(), &QItemSelectionModel::currentRowChanged, this, &MainWindow::handleLayerItemSelectionChanged);
 
-  disconnect(layerListModel, SIGNAL(dataChanged(QModelIndex,QModelIndex)),
-          this,        SLOT(handleLayerItemChanged(QModelIndex)));
+  disconnect(layerListModel, &LayerListModel::dataChanged, this, &MainWindow::handleLayerItemChanged);
 
-  disconnect(layerListModel, SIGNAL(rowsMoved(QModelIndex,int,int,QModelIndex,int)),
-          this,                 SLOT(handleLayerIndexesMoved()));
+  disconnect(layerListModel, &LayerListModel::rowsMoved, this, &MainWindow::handleLayerIndexesMoved);
 
-  disconnect(layerItemDelegate, SIGNAL(itemDuplicated(uid)),
-          this, SLOT(duplicateLayer(uid)));
+  disconnect(layerItemDelegate, &LayerItemDelegate::itemDuplicated, this, &MainWindow::duplicateLayer);
 
-  disconnect(layerItemDelegate, SIGNAL(itemRemoved(uid)),
-          this, SLOT(deleteLayer(uid)));
+  disconnect(layerItemDelegate, &LayerItemDelegate::itemRemoved, this, &MainWindow::deleteLayer);
 
-  disconnect(_preferenceDialog, SIGNAL(settingSaved()), this, SLOT(updateSettings()));
+  disconnect(_preferenceDialog, &PreferenceDialog::settingSaved, this, &MainWindow::updateSettings);
 }
 
 uid MainWindow::getItemId(const QListWidgetItem& item)
@@ -3928,7 +3895,7 @@ void MainWindow::startOscReceiver()
     osc_interface->start();
   }
   osc_timer = new QTimer(this); // FIXME: memleak?
-  connect(osc_timer, SIGNAL(timeout()), this, SLOT(pollOscInterface()));
+  connect(osc_timer, &QTimer::timeout, this, &MainWindow::pollOscInterface);
   osc_timer->start();
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -3974,14 +3974,17 @@ bool MainWindow::setOscPort(QString portNumber)
 #ifdef HAVE_MCP
 void MainWindow::startMcpServer()
 {
-  if (mcp_server.isNull())
-    mcp_server.reset(new McpServer(this));
-
   if (mcpListeningPort == 0)
   {
+    // Disabled (the default): tear down any running server so that setting the
+    // port to 0 at runtime actually stops listening.
+    mcp_server.reset();
     QMessageLogger(__FILE__, __LINE__, 0).info() << "MCP server disabled (port 0).";
     return;
   }
+
+  if (mcp_server.isNull())
+    mcp_server.reset(new McpServer(this));
 
   quint16 boundPort = mcp_server->start(static_cast<quint16>(mcpListeningPort));
   if (boundPort != 0)

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -175,6 +175,9 @@ private slots:
 
   void openShortcutWindow();
 
+  /// Shows the first-run / onboarding welcome dialog.
+  void showWelcomeDialog();
+
   void updateSettings();
 
   void updateLayerListColumnWidth();
@@ -483,6 +486,7 @@ private:
   QAction *docAction;
   QAction *feedbackAction;
   QAction *shortcutAction;
+  QAction *welcomeAction;
 
   // Screen output action
   QList<QAction *> screenActions;

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -543,6 +543,9 @@ private:
   // OSC.
   OscInterface::ptr osc_interface;
   int oscListeningPort;
+  // When false (default), OSC binds to loopback only; true widens it to all
+  // network interfaces. OSC is unauthenticated, so network access is opt-in.
+  bool oscAcceptNetwork;
   QTimer *osc_timer;
 
 #ifdef HAVE_MCP
@@ -655,6 +658,9 @@ public:
   void startFullScreen();
   bool setOscPort(QString portNumber);
   bool setOscPort(int portNumber);
+  // Stores whether OSC accepts datagrams from the network. Takes effect the
+  // next time startOscReceiver() runs (setOscPort triggers it on Apply).
+  void setOscAcceptNetwork(bool accept) { oscAcceptNetwork = accept; }
   int getOscPort() const;
   void setVerbose(bool verbose);
 #ifdef HAVE_MCP

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -546,6 +546,9 @@ private:
   // When false (default), OSC binds to loopback only; true widens it to all
   // network interfaces. OSC is unauthenticated, so network access is opt-in.
   bool oscAcceptNetwork;
+  // When false (default), the OSC /mapmap/quit command is ignored so a remote
+  // sender cannot close the application mid-show.
+  bool oscAllowQuit;
   QTimer *osc_timer;
 
 #ifdef HAVE_MCP
@@ -661,6 +664,9 @@ public:
   // Stores whether OSC accepts datagrams from the network. Takes effect the
   // next time startOscReceiver() runs (setOscPort triggers it on Apply).
   void setOscAcceptNetwork(bool accept) { oscAcceptNetwork = accept; }
+  // Whether the OSC /mapmap/quit command may close the application.
+  bool isOscQuitAllowed() const { return oscAllowQuit; }
+  void setOscAllowQuit(bool allow) { oscAllowQuit = allow; }
   int getOscPort() const;
   void setVerbose(bool verbose);
 #ifdef HAVE_MCP

--- a/src/gui/MapperGLCanvasToolbar.cpp
+++ b/src/gui/MapperGLCanvasToolbar.cpp
@@ -58,7 +58,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   _zoomInButton->setToolTip(tr("Enlarge the shape"));
   _zoomInButton->setFixedSize(QSize(MM::ZOOM_TOOLBAR_BUTTON_SIZE, MM::ZOOM_TOOLBAR_BUTTON_SIZE));
   _zoomInButton->setObjectName("zoom-in");
-  connect(_zoomInButton, SIGNAL(clicked()), _canvas, SLOT(increaseZoomLevel()));
+  connect(_zoomInButton, &QAbstractButton::clicked, _canvas, &MapperGLCanvas::increaseZoomLevel);
   // Zoom Out button
   _zoomOutButton = new QToolButton;
   _zoomOutButton->setIcon(QIcon(":/zoom-out"));
@@ -66,7 +66,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   _zoomOutButton->setToolTip(tr("Shrink the shape"));
   _zoomOutButton->setFixedSize(QSize(MM::ZOOM_TOOLBAR_BUTTON_SIZE, MM::ZOOM_TOOLBAR_BUTTON_SIZE));
   _zoomOutButton->setObjectName("zoom-out");
-  connect(_zoomOutButton, SIGNAL(clicked()), _canvas, SLOT(decreaseZoomLevel()));
+  connect(_zoomOutButton, &QAbstractButton::clicked, _canvas, &MapperGLCanvas::decreaseZoomLevel);
   // Reset to normal size button.
   _resetZoomButton = new QToolButton;
   _resetZoomButton->setIcon(QIcon(":/reset-zoom"));
@@ -74,7 +74,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   _resetZoomButton->setToolTip(tr("Reset the shape to the normal size"));
   _resetZoomButton->setFixedSize(QSize(MM::ZOOM_TOOLBAR_BUTTON_SIZE, MM::ZOOM_TOOLBAR_BUTTON_SIZE));
   _resetZoomButton->setObjectName("reset-zoom");
-  connect(_resetZoomButton, SIGNAL(clicked()), _canvas, SLOT(resetZoomLevel()));
+  connect(_resetZoomButton, &QAbstractButton::clicked, _canvas, &MapperGLCanvas::resetZoomLevel);
   // Fit to view button
   _fitToViewButton = new QToolButton;
   _fitToViewButton->setIcon(QIcon(":/zoom-fit"));
@@ -82,7 +82,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   _fitToViewButton->setToolTip(tr("Fit the shape to content view"));
   _fitToViewButton->setFixedSize(QSize(MM::ZOOM_TOOLBAR_BUTTON_SIZE, MM::ZOOM_TOOLBAR_BUTTON_SIZE));
   _fitToViewButton->setObjectName("zoom-fit");
-  connect(_fitToViewButton, SIGNAL(clicked()), _canvas, SLOT(fitShapeToView()));
+  connect(_fitToViewButton, &QAbstractButton::clicked, _canvas, &MapperGLCanvas::fitShapeToView);
 
   // Create the dropdowm menu
   _dropdownMenu = new QComboBox;
@@ -92,7 +92,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   // Create if empty or update list
   updateDropdownMenu();
   // And listen
-  connect(_dropdownMenu, SIGNAL(activated(QString)), _canvas, SLOT(setZoomFromMenu(QString)));
+  connect(_dropdownMenu, &QComboBox::textActivated, _canvas, &MapperGLCanvas::setZoomFromMenu);
 
   // Add widgets into layout
   toolbarLayout->addWidget(_titleLabel, 0, Qt::AlignVCenter);
@@ -106,7 +106,7 @@ void MapperGLCanvasToolbar::createZoomToolsLayout()
   // Insert layout in widget
   setLayout(toolbarLayout);
 
-  connect(_canvas, SIGNAL(zoomFactorChanged(qreal)), this, SLOT(updateDropdownMenu(qreal)));
+  connect(_canvas, &MapperGLCanvas::zoomFactorChanged, this, &MapperGLCanvasToolbar::updateDropdownMenu);
 }
 
 void MapperGLCanvasToolbar::showZoomToolBar(bool visible)

--- a/src/gui/PreferenceDialog.cpp
+++ b/src/gui/PreferenceDialog.cpp
@@ -124,6 +124,8 @@ bool PreferenceDialog::loadSettings()
   _oscSameMediaSourceBox->setChecked(settings.value("oscSameMediaSource", MM::OSC_SAME_MEDIA_SOURCE).toBool());
   // Accept OSC from the network (off by default: OSC is unauthenticated)
   _oscAcceptNetworkBox->setChecked(settings.value("oscAcceptNetwork", false).toBool());
+  // Allow the OSC quit command (off by default)
+  _oscAllowQuitBox->setChecked(settings.value("oscAllowQuit", false).toBool());
 #ifdef HAVE_MCP
   // MCP port
   _mcpPortNumber->setValue(settings.value("mcpListeningPort", MM::DEFAULT_MCP_PORT).toInt());
@@ -141,6 +143,9 @@ void PreferenceDialog::applySettings()
   // OSC network exposure. Set before setOscPort(), which rebinds the receiver.
   settings.setValue("oscAcceptNetwork", _oscAcceptNetworkBox->isChecked());
   mainWindow->setOscAcceptNetwork(_oscAcceptNetworkBox->isChecked());
+  // Whether OSC may quit the application.
+  settings.setValue("oscAllowQuit", _oscAllowQuitBox->isChecked());
+  mainWindow->setOscAllowQuit(_oscAllowQuitBox->isChecked());
   // Listen port
   settings.setValue("oscListeningPort", _listenPortNumber->value());
   mainWindow->setOscPort(settings.value("oscListeningPort").toInt());
@@ -363,6 +368,11 @@ void PreferenceDialog::createControlsPage()
   _oscAcceptNetworkBox->setToolTip(tr("When off, OSC is only reachable from this computer (127.0.0.1). "
                                       "Enable only on a trusted show network — OSC has no authentication."));
 
+  _oscAllowQuitBox = new QCheckBox(tr("Allow OSC to quit the application"));
+  _oscAllowQuitBox->setChecked(false);
+  _oscAllowQuitBox->setToolTip(tr("When off, the /mapmap/quit OSC command is ignored so a remote "
+                                  "sender cannot close the application during a show."));
+
   QFormLayout *listenPortForm = new QFormLayout;
   listenPortForm->setContentsMargins(margins);
   listenPortForm->addRow(tr("on port"), _listenPortNumber);
@@ -387,6 +397,7 @@ void PreferenceDialog::createControlsPage()
   oscLayout->addLayout(listenPortForm, 1);
   oscLayout->addWidget(_oscSameMediaSourceBox, 1);
   oscLayout->addWidget(_oscAcceptNetworkBox, 1);
+  oscLayout->addWidget(_oscAllowQuitBox, 1);
   oscLayout->addLayout(listenAddressForm, 3);
 
   _oscWidget->setLayout(oscLayout);

--- a/src/gui/PreferenceDialog.cpp
+++ b/src/gui/PreferenceDialog.cpp
@@ -53,8 +53,8 @@ PreferenceDialog::PreferenceDialog(QWidget* parent) :
   mainLayout->addWidget(_buttonBox, 1, 0, 1, 2);
   setLayout(mainLayout);
 
-  connect(_buttonBox, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(_buttonBox, SIGNAL(rejected()), this, SLOT(reject()));
+  connect(_buttonBox, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(_buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
 
   setWindowTitle(tr("Preferences"));
   _listWidget->setCurrentRow(0);
@@ -231,7 +231,7 @@ void PreferenceDialog::createMappingPage()
     stickList.append(QString::number(i * 10));
   _stickyRadiusBox->addItems(stickList);
   // Enable box only if sticky vertices is enabled
-  connect(_stickyVerticesBox, SIGNAL(toggled(bool)), _stickyRadiusBox, SLOT(setEnabled(bool)));
+  connect(_stickyVerticesBox, &QCheckBox::toggled, _stickyRadiusBox, &QWidget::setEnabled);
 
   QFormLayout *stickRadiusForm = new QFormLayout;
   stickRadiusForm->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
@@ -379,7 +379,7 @@ void PreferenceDialog::createControlsPage()
 
   _machineAddressLabel = new QLabel;
   _ipRefreshButton = new QPushButton(tr("Refresh"));
-  connect(_ipRefreshButton, SIGNAL(clicked()), this, SLOT(refreshCurrentIP()));
+  connect(_ipRefreshButton, &QAbstractButton::clicked, this, &PreferenceDialog::refreshCurrentIP);
 
   QHBoxLayout *listenAddressLayout = new QHBoxLayout;
   listenAddressLayout->addWidget(_machineAddressLabel);
@@ -486,7 +486,7 @@ void PreferenceDialog::createPreferencesList()
   _stackedLayout->addWidget(_controlsPage);
   _stackedLayout->addWidget(_advancedPage);
   // Sync list and pages
-  connect(_listWidget, SIGNAL(currentRowChanged(int)), _stackedLayout, SLOT(setCurrentIndex(int)));
+  connect(_listWidget, &QListWidget::currentRowChanged, _stackedLayout, &QStackedLayout::setCurrentIndex);
 }
 
 void PreferenceDialog::createLanguageList()

--- a/src/gui/PreferenceDialog.cpp
+++ b/src/gui/PreferenceDialog.cpp
@@ -119,6 +119,8 @@ bool PreferenceDialog::loadSettings()
                                          settings.value("toolbarIconSize", MM::TOOLBAR_ICON_SIZE)));
   // Set language
   _languageBox->setCurrentIndex(_languageBox->findData(settings.value("language", MM::DEFAULT_LANGUAGE)));
+  // Show the welcome dialog at startup (same key WelcomeDialog reads/writes).
+  _showWelcomeBox->setChecked(settings.value("showWelcomeOnStartup", true).toBool());
 
   // Allow OSC message with same media source
   _oscSameMediaSourceBox->setChecked(settings.value("oscSameMediaSource", MM::OSC_SAME_MEDIA_SOURCE).toBool());
@@ -157,6 +159,7 @@ void PreferenceDialog::applySettings()
   settings.setValue("showResolution", _showResolutionBox->isChecked());
   // Show control on mouse hover
   settings.setValue("showControlOnMouseOver", _showControlOnOverBox->isChecked());
+  settings.setValue("showWelcomeOnStartup", _showWelcomeBox->isChecked());
   // Set preferred test signal pattern
   for (QRadioButton *radio: _radioGroup) {
     if (radio->isChecked()) {
@@ -210,9 +213,12 @@ void PreferenceDialog::createInterfacePage()
   toolbarIconSizeForm->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
   toolbarIconSizeForm->addRow(tr("Toolbar icon size (requires restart)"), _toolbarIconSizeBox);
 
+  _showWelcomeBox = new QCheckBox(tr("Show the welcome dialog at startup"));
+
   QVBoxLayout *interfaceLayout = new QVBoxLayout;
   interfaceLayout->addLayout(languageForm);
   interfaceLayout->addLayout(toolbarIconSizeForm);
+  interfaceLayout->addWidget(_showWelcomeBox);
 
   _interfacePage->setLayout(interfaceLayout);
 }
@@ -362,6 +368,11 @@ void PreferenceDialog::createControlsPage()
 
   _oscSameMediaSourceBox = new QCheckBox(tr("Allow message with existing media source"));
   _oscSameMediaSourceBox->setChecked(false);
+  _oscSameMediaSourceBox->setToolTip(tr(
+      "When off (the default), an OSC message that sets a paint's media to the "
+      "file it already uses is ignored, so repeated messages don't reload — and "
+      "restart — the same video. Turn it on to reload the media anyway, for "
+      "example to restart a clip from the beginning over OSC."));
 
   _oscAcceptNetworkBox = new QCheckBox(tr("Accept OSC from the network (less secure)"));
   _oscAcceptNetworkBox->setChecked(false);

--- a/src/gui/PreferenceDialog.cpp
+++ b/src/gui/PreferenceDialog.cpp
@@ -122,6 +122,8 @@ bool PreferenceDialog::loadSettings()
 
   // Allow OSC message with same media source
   _oscSameMediaSourceBox->setChecked(settings.value("oscSameMediaSource", MM::OSC_SAME_MEDIA_SOURCE).toBool());
+  // Accept OSC from the network (off by default: OSC is unauthenticated)
+  _oscAcceptNetworkBox->setChecked(settings.value("oscAcceptNetwork", false).toBool());
 #ifdef HAVE_MCP
   // MCP port
   _mcpPortNumber->setValue(settings.value("mcpListeningPort", MM::DEFAULT_MCP_PORT).toInt());
@@ -136,6 +138,9 @@ void PreferenceDialog::applySettings()
 {
   QSettings settings;
   MainWindow *mainWindow = MainWindow::window();
+  // OSC network exposure. Set before setOscPort(), which rebinds the receiver.
+  settings.setValue("oscAcceptNetwork", _oscAcceptNetworkBox->isChecked());
+  mainWindow->setOscAcceptNetwork(_oscAcceptNetworkBox->isChecked());
   // Listen port
   settings.setValue("oscListeningPort", _listenPortNumber->value());
   mainWindow->setOscPort(settings.value("oscListeningPort").toInt());
@@ -353,6 +358,11 @@ void PreferenceDialog::createControlsPage()
   _oscSameMediaSourceBox = new QCheckBox(tr("Allow message with existing media source"));
   _oscSameMediaSourceBox->setChecked(false);
 
+  _oscAcceptNetworkBox = new QCheckBox(tr("Accept OSC from the network (less secure)"));
+  _oscAcceptNetworkBox->setChecked(false);
+  _oscAcceptNetworkBox->setToolTip(tr("When off, OSC is only reachable from this computer (127.0.0.1). "
+                                      "Enable only on a trusted show network — OSC has no authentication."));
+
   QFormLayout *listenPortForm = new QFormLayout;
   listenPortForm->setContentsMargins(margins);
   listenPortForm->addRow(tr("on port"), _listenPortNumber);
@@ -376,6 +386,7 @@ void PreferenceDialog::createControlsPage()
   oscLayout->addWidget(_listenMessageBox, 1);
   oscLayout->addLayout(listenPortForm, 1);
   oscLayout->addWidget(_oscSameMediaSourceBox, 1);
+  oscLayout->addWidget(_oscAcceptNetworkBox, 1);
   oscLayout->addLayout(listenAddressForm, 3);
 
   _oscWidget->setLayout(oscLayout);

--- a/src/gui/PreferenceDialog.h
+++ b/src/gui/PreferenceDialog.h
@@ -110,6 +110,7 @@ private:
   QPushButton *_ipRefreshButton;
   QCheckBox *_oscSameMediaSourceBox;
   QCheckBox *_oscAcceptNetworkBox;
+  QCheckBox *_oscAllowQuitBox;
 #ifdef HAVE_MCP
   // MCP
   QWidget *_mcpWidget;

--- a/src/gui/PreferenceDialog.h
+++ b/src/gui/PreferenceDialog.h
@@ -97,6 +97,7 @@ private:
   QLabel *_palTestImg;
   QLabel *_ntscTestImg;
   QCheckBox *_showControlOnOverBox;
+  QCheckBox *_showWelcomeBox;
 
   // Controls widgets
   // OSC

--- a/src/gui/PreferenceDialog.h
+++ b/src/gui/PreferenceDialog.h
@@ -109,6 +109,7 @@ private:
   QSpinBox *_listenPortNumber;
   QPushButton *_ipRefreshButton;
   QCheckBox *_oscSameMediaSourceBox;
+  QCheckBox *_oscAcceptNetworkBox;
 #ifdef HAVE_MCP
   // MCP
   QWidget *_mcpWidget;

--- a/src/gui/SourceGui.cpp
+++ b/src/gui/SourceGui.cpp
@@ -266,7 +266,7 @@ SyphonGui::SyphonGui(Source::ptr source)
   refreshServers();
 
   _refreshTimer = new QTimer(this);
-  connect(_refreshTimer, SIGNAL(timeout()), this, SLOT(refreshServers()));
+  connect(_refreshTimer, &QTimer::timeout, this, &SyphonGui::refreshServers);
   _refreshTimer->start(1000);
 }
 

--- a/src/gui/SourceGui.cpp
+++ b/src/gui/SourceGui.cpp
@@ -35,8 +35,8 @@ SourceGui::SourceGui(Source::ptr source)
 
   _propertyBrowser->setFactoryForManager(_variantManager, _variantFactory);
 
-  connect(_variantManager, SIGNAL(valueChanged(QtProperty*, const QVariant&)),
-          this,            SLOT(setValue(QtProperty*, const QVariant&)));
+  connect(_variantManager, &QtVariantPropertyManager::valueChanged,
+          this, qOverload<QtProperty*, const QVariant&>(&SourceGui::setValue));
 
   // Mapping UID.
   _idItem = _variantManager->addProperty(QMetaType::Int, QObject::tr("ID"));

--- a/src/gui/SyphonServerDialog.cpp
+++ b/src/gui/SyphonServerDialog.cpp
@@ -60,15 +60,15 @@ SyphonServerDialog::SyphonServerDialog(QWidget* parent)
       new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
   layout->addWidget(buttons);
 
-  connect(buttons, SIGNAL(accepted()), this, SLOT(accept()));
-  connect(buttons, SIGNAL(rejected()), this, SLOT(reject()));
-  connect(_list, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(accept()));
+  connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+  connect(_list, &QListWidget::itemDoubleClicked, this, &QDialog::accept);
 
   refresh();
 
   // Syphon servers can appear/disappear at any time; keep the list current.
   _timer = new QTimer(this);
-  connect(_timer, SIGNAL(timeout()), this, SLOT(refresh()));
+  connect(_timer, &QTimer::timeout, this, &SyphonServerDialog::refresh);
   _timer->start(1000);
 }
 

--- a/src/gui/WelcomeDialog.cpp
+++ b/src/gui/WelcomeDialog.cpp
@@ -1,0 +1,84 @@
+/*
+ * WelcomeDialog.cpp
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "WelcomeDialog.h"
+
+#include <QtWidgets>
+#include <QDesktopServices>
+
+#include "MM.h"
+
+namespace mmp {
+
+namespace {
+const char* kShowKey = "showWelcomeOnStartup";
+}
+
+WelcomeDialog::WelcomeDialog(QWidget* parent) : QDialog(parent)
+{
+  setWindowTitle(tr("Welcome to %1").arg(MM::APPLICATION_NAME));
+
+  QVBoxLayout* layout = new QVBoxLayout(this);
+  layout->setContentsMargins(24, 24, 24, 24);
+  layout->setSpacing(12);
+
+  QLabel* titleImage = new QLabel;
+  titleImage->setPixmap(QPixmap(":/mapmap-title-light").scaledToWidth(240, Qt::SmoothTransformation));
+  titleImage->setAlignment(Qt::AlignCenter);
+  layout->addWidget(titleImage);
+
+  QLabel* text = new QLabel(tr(
+      "MapMap projects video and images onto real surfaces.\n\n"
+      "To get started, import a media file to create a paint, then add a shape "
+      "to project it onto."));
+  text->setWordWrap(true);
+  text->setAlignment(Qt::AlignCenter);
+  layout->addWidget(text);
+
+  QPushButton* importButton = new QPushButton(tr("Import a media file…"));
+  importButton->setDefault(true);
+  layout->addWidget(importButton);
+
+  QPushButton* docButton = new QPushButton(tr("Read the documentation"));
+  layout->addWidget(docButton);
+
+  _showOnStartupBox = new QCheckBox(tr("Show this window at startup"));
+  _showOnStartupBox->setChecked(showOnStartup());
+  layout->addWidget(_showOnStartupBox);
+
+  QDialogButtonBox* buttons = new QDialogButtonBox(QDialogButtonBox::Close);
+  layout->addWidget(buttons);
+
+  connect(importButton, &QAbstractButton::clicked, this, [this]() {
+    emit importMediaRequested();
+    accept();
+  });
+  connect(docButton, &QAbstractButton::clicked, this, []() {
+    QDesktopServices::openUrl(QUrl(MM::WEBSITE_URL));
+  });
+  connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::accept);
+  connect(_showOnStartupBox, &QCheckBox::toggled, this, [](bool on) {
+    QSettings().setValue(kShowKey, on);
+  });
+}
+
+bool WelcomeDialog::showOnStartup()
+{
+  return QSettings().value(kShowKey, true).toBool();
+}
+
+}

--- a/src/gui/WelcomeDialog.h
+++ b/src/gui/WelcomeDialog.h
@@ -1,0 +1,53 @@
+/*
+ * WelcomeDialog.h
+ *
+ * A small first-run onboarding dialog: it greets the user, points at the two
+ * first steps (import a media file, read the documentation) and lets them opt
+ * out of showing it on future launches.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef WELCOME_DIALOG_H_
+#define WELCOME_DIALOG_H_
+
+#include <QDialog>
+
+QT_BEGIN_NAMESPACE
+class QCheckBox;
+QT_END_NAMESPACE
+
+namespace mmp {
+
+class WelcomeDialog : public QDialog
+{
+  Q_OBJECT
+
+public:
+  explicit WelcomeDialog(QWidget* parent = nullptr);
+
+  /// Whether the welcome dialog should be shown automatically on launch.
+  static bool showOnStartup();
+
+signals:
+  /// Emitted when the user chooses to import a media file from the dialog.
+  void importMediaRequested();
+
+private:
+  QCheckBox* _showOnStartupBox;
+};
+
+}
+
+#endif /* WELCOME_DIALOG_H_ */

--- a/src/gui/gui.pri
+++ b/src/gui/gui.pri
@@ -19,7 +19,8 @@ HEADERS += $$PWD/AboutDialog.h \
     $$PWD/PreferenceDialog.h \
     $$PWD/ShapeControlPainter.h \
     $$PWD/ShapeGraphicsItem.h \
-    $$PWD/ShortcutWindow.h
+    $$PWD/ShortcutWindow.h \
+    $$PWD/WelcomeDialog.h
 
 SOURCES += $$PWD/AboutDialog.cpp \
     $$PWD/ConsoleWindow.cpp \
@@ -35,7 +36,8 @@ SOURCES += $$PWD/AboutDialog.cpp \
     $$PWD/PreferenceDialog.cpp \
     $$PWD/ShapeControlPainter.cpp \
     $$PWD/ShapeGraphicsItem.cpp \
-    $$PWD/ShortcutWindow.cpp
+    $$PWD/ShortcutWindow.cpp \
+    $$PWD/WelcomeDialog.cpp
 
 # Syphon source picker (macOS-only).
 macx {

--- a/src/shape/Shape.cpp
+++ b/src/shape/Shape.cpp
@@ -110,8 +110,13 @@ void MShape::read(const QJsonObject& obj)
   QVector<QPointF> vertices;
   for (const auto& v : verticesArray)
   {
-    QJsonArray vertex = v.toArray();
-    vertices.append(QPointF(vertex[0].toDouble(), vertex[1].toDouble()));
+    const QJsonArray vertex = v.toArray();
+    if (vertex.size() < 2)
+    {
+      qWarning() << "Skipping malformed vertex (expected [x, y]) while reading shape.";
+      continue;
+    }
+    vertices.append(QPointF(vertex.at(0).toDouble(), vertex.at(1).toDouble()));
   }
 
   setVertices(vertices);

--- a/src/src.pri
+++ b/src/src.pri
@@ -53,7 +53,10 @@ macx {
   QMAKE_LFLAGS += -Wl,-rpath,@executable_path/../Frameworks
   syphon_framework.files = $$SYPHON_FRAMEWORK_DIR/Syphon.framework
   syphon_framework.path = Contents/Frameworks
-  QMAKE_BUNDLE_DATA += syphon_framework
+  # src.pri is pulled in once per sub-project (.pri), so guard the bundle-data
+  # entry to avoid emitting duplicate copy rules for Syphon.framework (which
+  # qmake reports as "overriding commands for target ...Syphon.framework").
+  !contains(QMAKE_BUNDLE_DATA, syphon_framework): QMAKE_BUNDLE_DATA += syphon_framework
 
   # Syphon OUTPUT (publishing MapMap's output as a Syphon server) is EXPERIMENTAL
   # and DISABLED by default: SyphonOpenGLServer cannot create its IOSurface

--- a/tests/TestFileVersion.cpp
+++ b/tests/TestFileVersion.cpp
@@ -1,0 +1,51 @@
+/*
+ * TestFileVersion.cpp
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "TestFileVersion.h"
+
+#include <QRegularExpression>
+
+#include "MM.h"
+
+using namespace mmp;
+
+namespace {
+// Mirrors ProjectReader::isValidVersion(): a file version is accepted iff it
+// matches MM::SUPPORTED_FILE_VERSIONS. Kept in sync with that method by design.
+bool isValidVersion(const QString& version)
+{
+  return QRegularExpression(MM::SUPPORTED_FILE_VERSIONS).match(version).hasMatch();
+}
+}
+
+void TestFileVersion::acceptsReleaseVersions()
+{
+  QVERIFY(isValidVersion("0.6.3"));   // previous stable format
+  QVERIFY(isValidVersion("1.0.0"));
+  QVERIFY(isValidVersion("2.10.15"));
+}
+
+void TestFileVersion::acceptsPreReleaseAndBuildSuffixes()
+{
+  // The 1.0 series ships pre-release builds; projects they save must reload.
+  QVERIFY(isValidVersion("1.0.0-alpha.1"));
+  QVERIFY(isValidVersion("1.0.0-rc.2"));
+  QVERIFY(isValidVersion("1.0.0+build.5"));
+}
+
+void TestFileVersion::rejectsMalformedVersions()
+{
+  QVERIFY(!isValidVersion(""));
+  QVERIFY(!isValidVersion("abc"));
+  QVERIFY(!isValidVersion("1.0"));       // too few components
+  QVERIFY(!isValidVersion("1.0.0.0"));   // too many components
+  QVERIFY(!isValidVersion("1.0.0-"));    // empty suffix
+  QVERIFY(!isValidVersion("v1.0.0"));    // stray prefix
+  QVERIFY(!isValidVersion(" 1.0.0"));    // leading whitespace
+}

--- a/tests/TestFileVersion.h
+++ b/tests/TestFileVersion.h
@@ -1,0 +1,30 @@
+/*
+ * TestFileVersion.h
+ *
+ * Unit tests for the project-file version compatibility contract
+ * (MM::SUPPORTED_FILE_VERSIONS), which ProjectReader uses to decide whether a
+ * .mmp file is loadable. Regression guard for the 1.0.0-alpha.1 version bump:
+ * a saved pre-release project must remain loadable.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef TEST_FILE_VERSION_H_
+#define TEST_FILE_VERSION_H_
+
+#include <QtTest/QtTest>
+
+class TestFileVersion : public QObject
+{
+  Q_OBJECT
+
+private slots:
+  void acceptsReleaseVersions();
+  void acceptsPreReleaseAndBuildSuffixes();
+  void rejectsMalformedVersions();
+};
+
+#endif /* TEST_FILE_VERSION_H_ */

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -18,6 +18,7 @@
 #include "TestUidAllocator.h"
 #include "TestShape.h"
 #include "TestOsc.h"
+#include "TestFileVersion.h"
 
 int main(int argc, char** argv)
 {
@@ -42,6 +43,10 @@ int main(int argc, char** argv)
   }
   {
     TestOsc test;
+    status |= QTest::qExec(&test, argc, argv);
+  }
+  {
+    TestFileVersion test;
     status |= QTest::qExec(&test, argc, argv);
   }
 

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -40,7 +40,8 @@ HEADERS += \
     TestUtil.h \
     TestUidAllocator.h \
     TestShape.h \
-    TestOsc.h
+    TestOsc.h \
+    TestFileVersion.h
 
 SOURCES += \
     $$CORE/MM.cpp \
@@ -58,4 +59,5 @@ SOURCES += \
     TestUtil.cpp \
     TestUidAllocator.cpp \
     TestShape.cpp \
-    TestOsc.cpp
+    TestOsc.cpp \
+    TestFileVersion.cpp

--- a/translations/mapmap_en.ts
+++ b/translations/mapmap_en.ts
@@ -27,7 +27,8 @@
 <context>
     <name>FileEdit</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="54"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="55"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="57"/>
         <source>Choose a file</source>
         <translation>Choose a file</translation>
     </message>
@@ -723,90 +724,127 @@ The original file is not found. Will you locate?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="144"/>
+        <location filename="../src/core/Commands.cpp" line="148"/>
         <source>Move vertex</source>
         <translation>Move vertex</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="190"/>
+        <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Rotate shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="194"/>
+        <location filename="../src/core/Commands.cpp" line="198"/>
         <source>Scale shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="231"/>
+        <location filename="../src/core/Commands.cpp" line="235"/>
         <source>Move shape</source>
         <translation>Move shape</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="261"/>
+        <location filename="../src/core/Commands.cpp" line="265"/>
         <source>Remove media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="299"/>
+        <location filename="../src/core/Commands.cpp" line="307"/>
         <source>Delete layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="329"/>
-        <source>Flipped Horizontally</source>
+        <location filename="../src/core/Commands.cpp" line="333"/>
+        <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="334"/>
-        <source>Flipped Vertically</source>
+        <source>Lower layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="154"/>
+        <location filename="../src/core/Commands.cpp" line="335"/>
+        <source>Raise layer to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="336"/>
+        <source>Lower layer to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="380"/>
+        <source>Flip Horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="385"/>
+        <source>Flip Vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="424"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="429"/>
+        <source>Rotate 90° CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="434"/>
+        <source>Rotate 180°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Layer.cpp" line="148"/>
         <source>Problem at creation of shape.</source>
         <translation>Problem at creation of shape.</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="170"/>
-        <location filename="../src/core/ProjectReader.cpp" line="169"/>
-        <location filename="../src/core/ProjectReader.cpp" line="198"/>
+        <location filename="../src/core/Layer.cpp" line="160"/>
+        <source>Unable to create shape of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation>Unable to create paint of type &apos;%1&apos;.</translation>
+        <translation type="vanished">Unable to create paint of type &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>Mapping</source>
         <translation type="vanished">Mapping</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="44"/>
-        <location filename="../src/gui/PaintGui.cpp" line="38"/>
+        <location filename="../src/gui/LayerGui.cpp" line="44"/>
+        <location filename="../src/gui/SourceGui.cpp" line="42"/>
         <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="50"/>
-        <location filename="../src/gui/PaintGui.cpp" line="44"/>
+        <location filename="../src/gui/LayerGui.cpp" line="50"/>
+        <location filename="../src/gui/SourceGui.cpp" line="48"/>
         <source>Opacity (%)</source>
         <translation>Opacity (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="63"/>
+        <location filename="../src/gui/LayerGui.cpp" line="63"/>
         <source>Output shape</source>
         <translation>Output shape</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="150"/>
+        <location filename="../src/gui/LayerGui.cpp" line="151"/>
         <source>Point %1</source>
         <translation>Point %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="194"/>
+        <location filename="../src/gui/LayerGui.cpp" line="195"/>
         <source>Mesh Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="423"/>
+        <location filename="../src/gui/LayerGui.cpp" line="424"/>
         <source>Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
@@ -815,7 +853,7 @@ The original file is not found. Will you locate?</translation>
         <translation type="vanished">Dimensions</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="288"/>
+        <location filename="../src/gui/LayerGui.cpp" line="289"/>
         <source>Input shape</source>
         <translation>Input shape</translation>
     </message>
@@ -824,44 +862,47 @@ The original file is not found. Will you locate?</translation>
         <translation type="vanished">Paint</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="88"/>
+        <location filename="../src/gui/SourceGui.cpp" line="92"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="56"/>
+        <location filename="../src/core/ProjectReader.cpp" line="50"/>
         <source>The contents of this file does not look like a MapMap project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="60"/>
+        <location filename="../src/core/ProjectReader.cpp" line="53"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="72"/>
+        <location filename="../src/core/ProjectReader.cpp" line="178"/>
+        <location filename="../src/core/ProjectReader.cpp" line="187"/>
+        <source>Unable to create layer of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="vanished">%1
 Line %2, column %3</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="156"/>
         <source>Problem at creation of paint.</source>
-        <translation>Problem at creation of paint.</translation>
+        <translation type="vanished">Problem at creation of paint.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="187"/>
         <source>Problem at creation of mapping.</source>
-        <translation>Problem at creation of mapping.</translation>
+        <translation type="vanished">Problem at creation of mapping.</translation>
     </message>
     <message>
-        <location filename="../src/app/main.cpp" line="185"/>
+        <location filename="../src/app/main.cpp" line="183"/>
         <source>Initiating program...</source>
         <translation>Initiating program...</translation>
     </message>
     <message>
-        <location filename="../src/app/main.cpp" line="240"/>
+        <location filename="../src/app/main.cpp" line="244"/>
         <source>Done.</source>
         <translation>Done.</translation>
     </message>
@@ -1035,12 +1076,12 @@ Line %2, column %3</translation>
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2523"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2521"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2543"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2541"/>
         <source>Select Font</source>
         <translation>Select Font</translation>
     </message>
@@ -1324,52 +1365,72 @@ Line %2, column %3</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="82"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="93"/>
         <source>MapMap is a free/open source video mapping software.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="84"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="94"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>See the </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="108"/>
         <source>%1 website</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="111"/>
+        <source>%1 is developed and sponsored by Art Plus Code. Need a custom video mapping installation, a new feature, integration or training? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="114"/>
+        <source>Hire us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="115"/>
+        <source>Enjoying %1? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="116"/>
+        <source>Support the project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="132"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="119"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="144"/>
         <source>Changelog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="137"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="159"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="173"/>
-        <source>OSC</source>
+        <location filename="../src/gui/AboutDialog.cpp" line="196"/>
+        <source>OSC Commands</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="149"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="170"/>
         <source>Contributors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="161"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="183"/>
         <source>License</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1397,7 +1458,7 @@ Line %2, column %3</translation>
         <translation type="unfinished">&amp;File</translation>
     </message>
     <message>
-        <location filename="../src/gui/ConsoleWindow.cpp" line="101"/>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="104"/>
         <source>MMM dd yy HH:mm</source>
         <translation type="unfinished">MMM dd yy HH:mm</translation>
     </message>
@@ -1405,52 +1466,75 @@ Line %2, column %3</translation>
 <context>
     <name>mmp::ImageGui</name>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="122"/>
+        <location filename="../src/gui/SourceGui.cpp" line="126"/>
         <source>Image file</source>
         <translation type="unfinished">Image file</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="124"/>
+        <location filename="../src/gui/SourceGui.cpp" line="128"/>
         <source>Image files (%1);;All files (*)</source>
         <translation type="unfinished">Image files (%1);;All files (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="128"/>
+        <location filename="../src/gui/SourceGui.cpp" line="132"/>
         <source>Speed (%)</source>
         <translation type="unfinished">Speed (%)</translation>
     </message>
 </context>
 <context>
+    <name>mmp::LayerItemDelegate</name>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="100"/>
+        <source>Solo mapping</source>
+        <translation type="unfinished">Solo mapping</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="112"/>
+        <source>Lock mapping</source>
+        <translation type="unfinished">Lock mapping</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="124"/>
+        <source>Duplicate mapping</source>
+        <translation type="unfinished">Duplicate mapping</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="136"/>
+        <source>Delete mapping</source>
+        <translation type="unfinished">Delete mapping</translation>
+    </message>
+</context>
+<context>
     <name>mmp::MainWindow</name>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="525"/>
-        <location filename="../src/gui/MainWindow.cpp" line="531"/>
+        <location filename="../src/gui/MainWindow.cpp" line="548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="554"/>
         <source>Open project</source>
         <translation type="unfinished">Open project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="527"/>
-        <location filename="../src/gui/MainWindow.cpp" line="533"/>
-        <location filename="../src/gui/MainWindow.cpp" line="565"/>
-        <location filename="../src/gui/MainWindow.cpp" line="571"/>
+        <location filename="../src/gui/MainWindow.cpp" line="550"/>
+        <location filename="../src/gui/MainWindow.cpp" line="556"/>
+        <location filename="../src/gui/MainWindow.cpp" line="588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="594"/>
         <source>MapMap files (*.%1)</source>
         <translation type="unfinished">MapMap files (*.%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="564"/>
-        <location filename="../src/gui/MainWindow.cpp" line="570"/>
+        <location filename="../src/gui/MainWindow.cpp" line="587"/>
+        <location filename="../src/gui/MainWindow.cpp" line="593"/>
         <source>Save project</source>
         <translation type="unfinished">Save project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="601"/>
-        <location filename="../src/gui/MainWindow.cpp" line="609"/>
+        <location filename="../src/gui/MainWindow.cpp" line="624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="632"/>
         <source>Import media source file</source>
         <translation type="unfinished">Import media source file</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="611"/>
+        <location filename="../src/gui/MainWindow.cpp" line="626"/>
+        <location filename="../src/gui/MainWindow.cpp" line="634"/>
         <source>Media files (%1 %2);;All files (*)</source>
         <translation type="unfinished">Media files (%1 %2);;All files (*)</translation>
     </message>
@@ -1459,39 +1543,44 @@ Line %2, column %3</translation>
         <translation type="obsolete">Available camera</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="646"/>
+        <location filename="../src/gui/MainWindow.cpp" line="672"/>
         <source>Camera device</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="647"/>
+        <location filename="../src/gui/MainWindow.cpp" line="673"/>
         <source>Select camera</source>
         <translation type="unfinished">Select camera</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>No camera available</source>
         <translation type="unfinished">No camera available</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>You can not use this feature!
 No camera available in your system</source>
         <translation type="unfinished">You can not use this feature!
 No camera available in your system</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="684"/>
-        <location filename="../src/gui/MainWindow.cpp" line="688"/>
+        <location filename="../src/gui/MainWindow.cpp" line="717"/>
+        <location filename="../src/gui/MainWindow.cpp" line="721"/>
         <source>Select Color</source>
         <translation type="unfinished">Select Color</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1449"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1605"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2453"/>
+        <location filename="../src/gui/MainWindow.cpp" line="755"/>
+        <source>Syphon source added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1620"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1781"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2769"/>
         <source>MapMap</source>
         <translation type="unfinished">MapMap</translation>
     </message>
@@ -1508,67 +1597,67 @@ No camera available in your system</translation>
         <translation type="obsolete">Mappings</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1619"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1795"/>
         <source>&amp;New</source>
         <translation type="unfinished">&amp;New</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1622"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1798"/>
         <source>Create a new project</source>
         <translation type="unfinished">Create a new project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1805"/>
         <source>&amp;Open...</source>
         <translation type="unfinished">&amp;Open...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1632"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1808"/>
         <source>Open an existing project</source>
         <translation type="unfinished">Open an existing project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1639"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1815"/>
         <source>&amp;Save</source>
         <translation type="unfinished">&amp;Save</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1642"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1818"/>
         <source>Save the project</source>
         <translation type="unfinished">Save the project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1649"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1825"/>
         <source>Save &amp;As...</source>
         <translation type="unfinished">Save &amp;As...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1652"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Save the project as...</source>
         <translation type="unfinished">Save the project as...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1681"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1857"/>
         <source>No Recents Videos</source>
         <translation type="unfinished">No Recents Videos</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1686"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1862"/>
         <source>&amp;Import Media File...</source>
         <translation type="unfinished">&amp;Import Media File...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1689"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Import a video or image file...</source>
         <translation type="unfinished">Import a video or image file...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1697"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1872"/>
         <source>Open &amp;Camera Device...</source>
         <translation type="unfinished">Open &amp;Camera Device...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1701"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Choose your camera device...</source>
         <translation type="unfinished">Choose your camera device...</translation>
     </message>
@@ -1577,37 +1666,36 @@ No camera available in your system</translation>
         <translation type="obsolete">Add &amp;Color Paint...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1711"/>
         <source>Add a color paint...</source>
-        <translation type="unfinished">Add a color paint...</translation>
+        <translation type="obsolete">Add a color paint...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1718"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1904"/>
         <source>E&amp;xit</source>
         <translation type="unfinished">E&amp;xit</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1720"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1906"/>
         <source>Exit the application</source>
         <translation type="unfinished">Exit the application</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>&amp;Undo</source>
         <translation type="unfinished">&amp;Undo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1734"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1920"/>
         <source>&amp;Redo</source>
         <translation type="unfinished">&amp;Redo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1741"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1927"/>
         <source>&amp;About MapMap</source>
         <translation type="unfinished">&amp;About MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1742"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1928"/>
         <source>Show the application&apos;s About box</source>
         <translation type="unfinished">Show the application&apos;s About box</translation>
     </message>
@@ -1664,12 +1752,12 @@ No camera available in your system</translation>
         <translation type="obsolete">Delete paint</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1855"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2099"/>
         <source>&amp;Preferences...</source>
         <translation type="unfinished">&amp;Preferences...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1858"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2102"/>
         <source>Configure preferences...</source>
         <translation type="unfinished">Configure preferences...</translation>
     </message>
@@ -1698,14 +1786,14 @@ No camera available in your system</translation>
         <translation type="obsolete">Add ellipse</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1899"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1902"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2143"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2146"/>
         <source>Play</source>
         <translation type="unfinished">Play</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1910"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2157"/>
         <source>Pause</source>
         <translation type="unfinished">Pause</translation>
     </message>
@@ -1714,22 +1802,22 @@ No camera available in your system</translation>
         <translation type="obsolete">Rewind</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1931"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2175"/>
         <source>Toggle &amp;Fullscreen</source>
         <translation type="unfinished">Toggle &amp;Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1934"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2178"/>
         <source>Toggle Fullscreen</source>
         <translation type="unfinished">Toggle Fullscreen</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1952"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2197"/>
         <source>&amp;Display Controls</source>
         <translation type="unfinished">&amp;Display Controls</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2200"/>
         <source>Display canvas controls</source>
         <translation type="unfinished">Display canvas controls</translation>
     </message>
@@ -1742,131 +1830,126 @@ No camera available in your system</translation>
         <translation type="obsolete">Display all canvas controls related to current paint</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1981"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2226"/>
         <source>&amp;Sticky Vertices</source>
         <translation type="unfinished">&amp;Sticky Vertices</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1984"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2229"/>
         <source>Enable sticky vertices</source>
         <translation type="unfinished">Enable sticky vertices</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1993"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2238"/>
         <source>Show &amp;Test Signal</source>
         <translation type="unfinished">Show &amp;Test Signal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1996"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2241"/>
         <source>Show Test signal</source>
         <translation type="unfinished">Show Test signal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2270"/>
         <source>Display &amp;Undo History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2017"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2280"/>
         <source>Open Conso&amp;le</source>
         <translation type="unfinished">Open Conso&amp;le</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2028"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2291"/>
         <source>Display &amp;Zoom Toolbar</source>
         <translation type="unfinished">Display &amp;Zoom Toolbar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2038"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2301"/>
         <source>&amp;Menu Bar</source>
         <translation type="unfinished">&amp;Menu Bar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2045"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>Main Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2312"/>
         <source>Switch to the Main layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2076"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2337"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2339"/>
         <source>Zoom In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2081"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2083"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2344"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2346"/>
         <source>Zoom Out</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2088"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2351"/>
         <source>Original Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2090"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2353"/>
         <source>Reset zoom to original size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2358"/>
         <source>Fit To View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2096"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2359"/>
         <source>Fit to viewport</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2103"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2366"/>
         <source>Report an issue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2106"/>
-        <source>Technical support</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2380"/>
         <source>Submit feedback via email</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2196"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2484"/>
         <source>&amp;View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2207"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>&amp;Output screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2961"/>
         <source> - Primary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3115"/>
         <source>Color source added</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3123"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3526"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3130"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3138"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3541"/>
         <source>Locate file %1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1879,27 +1962,27 @@ The original file is not found. Please locate.</source>
         <translation type="obsolete">Technical Support</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2377"/>
         <source>Documentation</source>
         <translation type="unfinished">Documentation</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2412"/>
         <source>&amp;File</source>
         <translation type="unfinished">&amp;File</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2427"/>
         <source>Open Recents Projects</source>
         <translation type="unfinished">Open Recents Projects</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2161"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2434"/>
         <source>Open Recents Videos</source>
         <translation type="unfinished">Open Recents Videos</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2172"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2445"/>
         <source>&amp;Edit</source>
         <translation type="unfinished">&amp;Edit</translation>
     </message>
@@ -1924,7 +2007,7 @@ The original file is not found. Please locate.</source>
         <translation type="obsolete">&amp;Tools</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2216"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2507"/>
         <source>&amp;Window</source>
         <translation type="unfinished">&amp;Window</translation>
     </message>
@@ -1933,241 +2016,337 @@ The original file is not found. Please locate.</source>
         <translation type="obsolete">Toolbars</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1450"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1621"/>
         <source>Remove this source and all its associated layers?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1693"/>
         <source>Input Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1537"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1709"/>
         <source>Output Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1583"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1758"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1584"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Layers</source>
         <translation type="unfinished">Layers</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1708"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1882"/>
         <source>Add &amp;Color Source...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1749"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1885"/>
+        <source>Add a color source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1893"/>
+        <source>Add &amp;Syphon Source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1896"/>
+        <source>Receive live video from another application via Syphon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1935"/>
         <source>Duplicate Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1751"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1937"/>
         <source>Duplicate layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1945"/>
         <source>Delete Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1761"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1947"/>
         <source>Delete layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1769"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Rename Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1771"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1957"/>
         <source>Rename layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1965"/>
         <source>Lock Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1780"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>Lock layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1790"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1976"/>
         <source>Hide Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1791"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1977"/>
         <source>Hide layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1801"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1987"/>
         <source>Solo Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1802"/>
-        <source>solo layer item</source>
+        <location filename="../src/gui/MainWindow.cpp" line="1988"/>
+        <source>Solo layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1812"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1813"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1998"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1999"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2006"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2014"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2015"/>
+        <source>Rotate 180°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2022"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2024"/>
         <source>Flip Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1820"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1821"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2031"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2033"/>
         <source>Flip Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Delete Source</source>
+        <location filename="../src/gui/MainWindow.cpp" line="2039"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2041"/>
+        <source>Raise</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1830"/>
-        <source>Delete source item</source>
+        <location filename="../src/gui/MainWindow.cpp" line="2047"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <source>Lower</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1838"/>
-        <source>Rename Source</source>
+        <location filename="../src/gui/MainWindow.cpp" line="2055"/>
+        <source>Raise to Top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1840"/>
-        <source>Rename source item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1848"/>
-        <source>Import New Media</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1849"/>
-        <source>Import new media file if not exists on the list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Add &amp;Mesh Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1868"/>
-        <source>Add mesh layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Add &amp;Triangle Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1879"/>
-        <source>Add triangle layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1887"/>
-        <source>Add &amp;Ellipse Layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1890"/>
-        <source>Add ellipse layer</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1921"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1924"/>
-        <source>Restart</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
-        <source>&amp;Display Controls of Layers of a Source</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1969"/>
-        <source>Display all canvas controls related to current source</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2053"/>
-        <source>Input editor Layout</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2056"/>
-        <source>Switch to the Input editor Layout.</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2060"/>
-        <source>Output Editor Layout</source>
+        <location filename="../src/gui/MainWindow.cpp" line="2057"/>
+        <source>Raise to top</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <source>Lower to Bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2065"/>
+        <source>Lower to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2072"/>
+        <source>Delete Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
+        <source>Delete source item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2082"/>
+        <source>Rename Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2084"/>
+        <source>Rename source item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2092"/>
+        <source>Import New Media</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2093"/>
+        <source>Import new media file if not exists on the list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
+        <source>Add &amp;Mesh Layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
+        <source>Add mesh layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2120"/>
+        <source>Add &amp;Triangle Layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2123"/>
+        <source>Add triangle layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2131"/>
+        <source>Add &amp;Ellipse Layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2134"/>
+        <source>Add ellipse layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2165"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2168"/>
+        <source>Restart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2211"/>
+        <source>&amp;Display Controls of Layers of a Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2214"/>
+        <source>Display all canvas controls related to current source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2254"/>
+        <source>&amp;Publish Syphon Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2255"/>
+        <source>Publish the output composition as a Syphon server other apps can receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2316"/>
+        <source>Input editor Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2319"/>
+        <source>Switch to the Input editor Layout.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2323"/>
+        <source>Output Editor Layout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2326"/>
         <source>Switch to the Output Editors Layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2240"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2369"/>
+        <source>Professional services &amp;&amp; custom development…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2370"/>
+        <source>Hire Art Plus Code for video mapping installations, custom features, integration and training</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2373"/>
+        <source>Support the project (donate)…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2374"/>
+        <source>Help fund MapMap&apos;s ongoing development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2383"/>
+        <source>&amp;Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2531"/>
         <source>&amp;Help</source>
         <translation type="unfinished">&amp;Help</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2268"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2560"/>
         <source>Change Layer Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2614"/>
         <source>&amp;Toolbar</source>
         <translation type="unfinished">&amp;Toolbar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2454"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2770"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
         <translation type="unfinished">The document has been modified.
 Do you want to save your changes?</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2476"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2490"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2792"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2806"/>
         <source>Error reading mapping project file</source>
         <translation type="unfinished">Error reading mapping project file</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2477"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2793"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3062"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation type="unfinished">Cannot read file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2491"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2807"/>
         <source>Parse error in file %1:
 
 %2</source>
@@ -2176,67 +2355,73 @@ Do you want to save your changes?</translation>
 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2814"/>
         <source>File loaded</source>
         <translation type="unfinished">File loaded</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2510"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2843"/>
         <source>Error saving mapping project</source>
         <translation type="unfinished">Error saving mapping project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2511"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2829"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation type="unfinished">Cannot write file %1:
 %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2844"/>
+        <source>Cannot rename temporary file to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2849"/>
         <source>File saved</source>
         <translation type="unfinished">File saved</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2865"/>
         <source>Untitled</source>
         <translation type="unfinished">Untitled</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
         <source>%1[*] - %2</source>
         <translation type="unfinished">%1[*] - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2726"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3061"/>
         <source>MapMap Project</source>
         <translation type="unfinished">MapMap Project</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2571"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2657"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2903"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2935"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2989"/>
         <source>&amp;%1 %2</source>
         <translation type="unfinished">&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2920"/>
         <source>Clear List</source>
         <translation type="unfinished">Clear List</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2591"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2923"/>
         <source>No Recents Projects</source>
         <translation type="unfinished">No Recents Projects</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2956"/>
         <source>%1 - %2x%3</source>
         <translation type="unfinished">%1 - %2x%3</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2758"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>File imported</source>
         <translation type="unfinished">File imported</translation>
     </message>
@@ -2245,17 +2430,17 @@ Do you want to save your changes?</translation>
         <translation type="obsolete">Color paint added</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3497"/>
         <source>Warning</source>
         <translation type="unfinished">Warning</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3498"/>
         <source>The following file is not supported: %1</source>
         <translation type="unfinished">The following file is not supported: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3122"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3525"/>
         <source>Cannot load movie</source>
         <translation type="unfinished">Cannot load movie</translation>
     </message>
@@ -2270,13 +2455,13 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Locate file « %1 »</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3132"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3535"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3543"/>
         <source>%1 files (%2)</source>
         <translation type="unfinished">%1 files (%2)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3265"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3668"/>
         <source>Undo history</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2284,22 +2469,22 @@ The original file is not found. Will you locate?</translation>
 <context>
     <name>mmp::MapperGLCanvasToolbar</name>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="54"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="58"/>
         <source>Enlarge the shape</source>
         <translation type="unfinished">Enlarge the shape</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="62"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="66"/>
         <source>Shrink the shape</source>
         <translation type="unfinished">Shrink the shape</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="70"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="74"/>
         <source>Reset the shape to the normal size</source>
         <translation type="unfinished">Reset the shape to the normal size</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="78"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="82"/>
         <source>Fit the shape to content view</source>
         <translation type="unfinished">Fit the shape to content view</translation>
     </message>
@@ -2307,35 +2492,31 @@ The original file is not found. Will you locate?</translation>
 <context>
     <name>mmp::MappingItemDelegate</name>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="99"/>
         <source>Solo mapping</source>
-        <translation type="unfinished">Solo mapping</translation>
+        <translation type="obsolete">Solo mapping</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="111"/>
         <source>Lock mapping</source>
-        <translation type="unfinished">Lock mapping</translation>
+        <translation type="obsolete">Lock mapping</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="123"/>
         <source>Duplicate mapping</source>
-        <translation type="unfinished">Duplicate mapping</translation>
+        <translation type="obsolete">Duplicate mapping</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="135"/>
         <source>Delete mapping</source>
-        <translation type="unfinished">Delete mapping</translation>
+        <translation type="obsolete">Delete mapping</translation>
     </message>
 </context>
 <context>
-    <name>mmp::MeshTextureMappingGui</name>
+    <name>mmp::MeshTextureLayerGui</name>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="427"/>
+        <location filename="../src/gui/LayerGui.cpp" line="428"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="428"/>
+        <location filename="../src/gui/LayerGui.cpp" line="429"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2348,37 +2529,37 @@ The original file is not found. Will you locate?</translation>
         <translation type="unfinished">Preferences</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="182"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="201"/>
         <source>Large</source>
         <translation type="unfinished">Large</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="183"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="202"/>
         <source>Medium</source>
         <translation type="unfinished">Medium</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="184"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="203"/>
         <source>Small</source>
         <translation type="unfinished">Small</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="188"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Language (requires restart)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="192"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="211"/>
         <source>Toolbar icon size (requires restart)</source>
         <translation type="unfinished">Toolbar icon size (requires restart)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="226"/>
         <source>Enable Sticky vertices</source>
         <translation type="unfinished">Enable Sticky vertices</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="220"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="239"/>
         <source>Sensitivity</source>
         <translation type="unfinished">Sensitivity</translation>
     </message>
@@ -2391,7 +2572,7 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Vertex</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="337"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="356"/>
         <source>Listen to OSC messages</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2400,7 +2581,7 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Shape</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="404"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="457"/>
         <source>Layers</source>
         <translation type="unfinished">Layers</translation>
     </message>
@@ -2409,17 +2590,17 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Show resolution on output</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="259"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="278"/>
         <source>Classic test card</source>
         <translation type="unfinished">Classic test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="260"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="279"/>
         <source>PAL test card</source>
         <translation type="unfinished">PAL test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="261"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="280"/>
         <source>NTSC test card</source>
         <translation type="unfinished">NTSC test card</translation>
     </message>
@@ -2440,67 +2621,102 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Listen OSC messages</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="222"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="241"/>
         <source>Vertices</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="248"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="267"/>
         <source>Only show output controls on mouse over</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="253"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="272"/>
         <source>Output Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="257"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="276"/>
         <source>Show resolution on output test cards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="290"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="309"/>
         <source>Test Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="344"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="363"/>
         <source>Allow message with existing media source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="349"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="366"/>
+        <source>Accept OSC from the network (less secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="368"/>
+        <source>When off, OSC is only reachable from this computer (127.0.0.1). Enable only on a trusted show network — OSC has no authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="371"/>
+        <source>Allow OSC to quit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="373"/>
+        <source>When off, the /mapmap/quit OSC command is ignored so a remote sender cannot close the application during a show.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="378"/>
         <source>on port</source>
         <translation type="unfinished">on port</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="352"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="381"/>
         <source>Refresh</source>
         <translation type="unfinished">Refresh</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="362"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="391"/>
         <source>Local IP</source>
         <translation type="unfinished">Local IP</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="374"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="405"/>
         <source>OSC Setup</source>
         <translation type="unfinished">OSC Setup</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="387"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="414"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="418"/>
+        <source>MCP port (0 to disable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="426"/>
+        <source>MCP Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="440"/>
         <source>Play in loop (requires restart)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="395"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="448"/>
         <source>Playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="401"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="454"/>
         <source>Interface</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2509,19 +2725,121 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Mapping &amp; Shape</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="407"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="460"/>
         <source>Output</source>
         <translation type="unfinished">Output</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="410"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="463"/>
         <source>Controls</source>
         <translation type="unfinished">Controls</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="413"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="466"/>
         <source>Advanced</source>
         <translation type="unfinished">Advanced</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::ShortcutWindow</name>
+    <message>
+        <location filename="../src/gui/ShortcutWindow.cpp" line="36"/>
+        <source>%1 - Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonGui</name>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="254"/>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="255"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="257"/>
+        <source>Respect source alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="304"/>
+        <source>(none)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="310"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="326"/>
+        <source>Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="330"/>
+        <source>No server selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="332"/>
+        <source>Waiting for server…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonServerDialog</name>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="41"/>
+        <source>Add Syphon Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="46"/>
+        <source>Choose a Syphon server to receive video from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="86"/>
+        <source>(Create without connecting yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="91"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="99"/>
+        <source>Application: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="100"/>
+        <source>Server: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="101"/>
+        <source>ID: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="107"/>
+        <source>No Syphon servers found yet. Open a Syphon-enabled app (Resolume, VDMX, a Simple Server, …), or create the source now and connect it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="111"/>
+        <source>%n Syphon server(s) available. The list updates automatically.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -2531,22 +2849,22 @@ The original file is not found. Will you locate?</translation>
         <translation type="obsolete">Video file</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="170"/>
+        <location filename="../src/gui/SourceGui.cpp" line="174"/>
         <source>Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="172"/>
+        <location filename="../src/gui/SourceGui.cpp" line="176"/>
         <source>Video files (%1);;All files (*)</source>
         <translation type="unfinished">Video files (%1);;All files (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="176"/>
+        <location filename="../src/gui/SourceGui.cpp" line="180"/>
         <source>Speed (%)</source>
         <translation type="unfinished">Speed (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="183"/>
+        <location filename="../src/gui/SourceGui.cpp" line="187"/>
         <source>Volume (%)</source>
         <translation type="unfinished">Volume (%)</translation>
     </message>

--- a/translations/mapmap_en.ts
+++ b/translations/mapmap_en.ts
@@ -121,8 +121,8 @@ No camera available in your system</translation>
         <translation type="vanished">Create a new project</translation>
     </message>
     <message>
-        <source>&amp;Open...</source>
-        <translation type="vanished">&amp;Open...</translation>
+        <source>&amp;Open…</source>
+        <translation type="vanished">&amp;Open…</translation>
     </message>
     <message>
         <source>Open an existing project</source>
@@ -137,32 +137,32 @@ No camera available in your system</translation>
         <translation type="vanished">Save the project</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation type="vanished">Save &amp;As...</translation>
+        <source>Save &amp;As…</source>
+        <translation type="vanished">Save &amp;As…</translation>
     </message>
     <message>
-        <source>Save the project as...</source>
-        <translation type="vanished">Save the project as...</translation>
+        <source>Save the project as…</source>
+        <translation type="vanished">Save the project as…</translation>
     </message>
     <message>
         <source>No Recents Videos</source>
         <translation type="vanished">No Recents Videos</translation>
     </message>
     <message>
-        <source>&amp;Import Media File...</source>
-        <translation type="vanished">&amp;Import Media File...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation type="vanished">&amp;Import Media File…</translation>
     </message>
     <message>
-        <source>Import a video or image file...</source>
-        <translation type="vanished">Import a video or image file...</translation>
+        <source>Import a video or image file…</source>
+        <translation type="vanished">Import a video or image file…</translation>
     </message>
     <message>
-        <source>Open &amp;Camera Device...</source>
-        <translation type="vanished">Open &amp;Camera Device...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation type="vanished">Open &amp;Camera Device…</translation>
     </message>
     <message>
-        <source>Choose your camera device...</source>
-        <translation type="vanished">Choose your camera device...</translation>
+        <source>Choose your camera device…</source>
+        <translation type="vanished">Choose your camera device…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -249,12 +249,12 @@ No camera available in your system</translation>
         <translation type="vanished">Delete paint</translation>
     </message>
     <message>
-        <source>&amp;Preferences...</source>
-        <translation type="vanished">&amp;Preferences...</translation>
+        <source>&amp;Preferences…</source>
+        <translation type="vanished">&amp;Preferences…</translation>
     </message>
     <message>
-        <source>Configure preferences...</source>
-        <translation type="vanished">Configure preferences...</translation>
+        <source>Configure preferences…</source>
+        <translation type="vanished">Configure preferences…</translation>
     </message>
     <message>
         <source>Add &amp;Mesh</source>
@@ -1608,8 +1608,8 @@ No camera available in your system</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1805"/>
-        <source>&amp;Open...</source>
-        <translation type="unfinished">&amp;Open...</translation>
+        <source>&amp;Open…</source>
+        <translation type="unfinished">&amp;Open…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1808"/>
@@ -1628,13 +1628,13 @@ No camera available in your system</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1825"/>
-        <source>Save &amp;As...</source>
-        <translation type="unfinished">Save &amp;As...</translation>
+        <source>Save &amp;As…</source>
+        <translation type="unfinished">Save &amp;As…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Save the project as...</source>
-        <translation type="unfinished">Save the project as...</translation>
+        <source>Save the project as…</source>
+        <translation type="unfinished">Save the project as…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1857"/>
@@ -1643,23 +1643,23 @@ No camera available in your system</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1862"/>
-        <source>&amp;Import Media File...</source>
-        <translation type="unfinished">&amp;Import Media File...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation type="unfinished">&amp;Import Media File…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Import a video or image file...</source>
-        <translation type="unfinished">Import a video or image file...</translation>
+        <source>Import a video or image file…</source>
+        <translation type="unfinished">Import a video or image file…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1872"/>
-        <source>Open &amp;Camera Device...</source>
-        <translation type="unfinished">Open &amp;Camera Device...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation type="unfinished">Open &amp;Camera Device…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Choose your camera device...</source>
-        <translation type="unfinished">Choose your camera device...</translation>
+        <source>Choose your camera device…</source>
+        <translation type="unfinished">Choose your camera device…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -1753,13 +1753,13 @@ No camera available in your system</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2099"/>
-        <source>&amp;Preferences...</source>
-        <translation type="unfinished">&amp;Preferences...</translation>
+        <source>&amp;Preferences…</source>
+        <translation type="unfinished">&amp;Preferences…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2102"/>
-        <source>Configure preferences...</source>
-        <translation type="unfinished">Configure preferences...</translation>
+        <source>Configure preferences…</source>
+        <translation type="unfinished">Configure preferences…</translation>
     </message>
     <message>
         <source>Add &amp;Mesh</source>
@@ -2042,22 +2042,22 @@ The original file is not found. Please locate.</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1882"/>
-        <source>Add &amp;Color Source...</source>
+        <source>Add &amp;Color Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1885"/>
-        <source>Add a color source...</source>
+        <source>Add a color source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1893"/>
-        <source>Add &amp;Syphon Source...</source>
+        <source>Add &amp;Syphon Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1896"/>
-        <source>Receive live video from another application via Syphon...</source>
+        <source>Receive live video from another application via Syphon…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mapmap_es.ts
+++ b/translations/mapmap_es.ts
@@ -4,7 +4,8 @@
 <context>
     <name>FileEdit</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="54"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="55"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="57"/>
         <source>Choose a file</source>
         <translation>Elegir un archivo</translation>
     </message>
@@ -12,12 +13,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/app/main.cpp" line="185"/>
+        <location filename="../src/app/main.cpp" line="183"/>
         <source>Initiating program...</source>
         <translation>Iniciando el programa...</translation>
     </message>
     <message>
-        <location filename="../src/app/main.cpp" line="240"/>
+        <location filename="../src/app/main.cpp" line="244"/>
         <source>Done.</source>
         <translation>Listo.</translation>
     </message>
@@ -37,122 +38,170 @@
         <translation>Duplicar capa</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="144"/>
+        <location filename="../src/core/Commands.cpp" line="148"/>
         <source>Move vertex</source>
         <translation>Mover el vértice</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="190"/>
+        <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Rotate shape</source>
         <translation>Rotar la forma</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="194"/>
+        <location filename="../src/core/Commands.cpp" line="198"/>
         <source>Scale shape</source>
         <translation>Escalar la forma</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="231"/>
+        <location filename="../src/core/Commands.cpp" line="235"/>
         <source>Move shape</source>
         <translation>Mover la forma</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="261"/>
+        <location filename="../src/core/Commands.cpp" line="265"/>
         <source>Remove media</source>
         <translation>Quitar multimedia</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="299"/>
+        <location filename="../src/core/Commands.cpp" line="307"/>
         <source>Delete layer</source>
         <translation>Eliminar capa</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="329"/>
-        <source>Flipped Horizontally</source>
-        <translation>Volteado horizontalmente</translation>
+        <location filename="../src/core/Commands.cpp" line="333"/>
+        <source>Raise layer</source>
+        <translation>Subir la capa</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="334"/>
-        <source>Flipped Vertically</source>
-        <translation>Volteado verticalmente</translation>
+        <source>Lower layer</source>
+        <translation>Bajar la capa</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="154"/>
+        <location filename="../src/core/Commands.cpp" line="335"/>
+        <source>Raise layer to top</source>
+        <translation>Subir la capa hasta arriba</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="336"/>
+        <source>Lower layer to bottom</source>
+        <translation>Bajar la capa hasta el fondo</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="380"/>
+        <source>Flip Horizontally</source>
+        <translation>Voltear horizontalmente</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="385"/>
+        <source>Flip Vertically</source>
+        <translation>Voltear verticalmente</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="424"/>
+        <source>Rotate 90° CW</source>
+        <translation>Rotar 90° en sentido horario</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="429"/>
+        <source>Rotate 90° CCW</source>
+        <translation>Rotar 90° en sentido antihorario</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="434"/>
+        <source>Rotate 180°</source>
+        <translation>Rotar 180°</translation>
+    </message>
+    <message>
+        <source>Flipped Horizontally</source>
+        <translation type="vanished">Volteado horizontalmente</translation>
+    </message>
+    <message>
+        <source>Flipped Vertically</source>
+        <translation type="vanished">Volteado verticalmente</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Layer.cpp" line="148"/>
         <source>Problem at creation of shape.</source>
         <translation>Problema al crear la forma.</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="170"/>
-        <location filename="../src/core/ProjectReader.cpp" line="169"/>
-        <location filename="../src/core/ProjectReader.cpp" line="198"/>
-        <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation>No se puede crear una pintura del tipo &apos;%1&apos;.</translation>
+        <location filename="../src/core/Layer.cpp" line="160"/>
+        <source>Unable to create shape of type &apos;%1&apos;.</source>
+        <translation>No se puede crear una forma del tipo &apos;%1&apos;.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="56"/>
+        <source>Unable to create paint of type &apos;%1&apos;.</source>
+        <translation type="vanished">No se puede crear una pintura del tipo &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/core/ProjectReader.cpp" line="50"/>
         <source>The contents of this file does not look like a MapMap project.</source>
         <translation>El contenido de este archivo no parece un proyecto de MapMap.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="60"/>
+        <location filename="../src/core/ProjectReader.cpp" line="53"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
         <translation>La versión de MapMap %1 usada para guardar este archivo no se puede leer con esta versión de MapMap %2.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="72"/>
+        <location filename="../src/core/ProjectReader.cpp" line="178"/>
+        <location filename="../src/core/ProjectReader.cpp" line="187"/>
+        <source>Unable to create layer of type &apos;%1&apos;.</source>
+        <translation>No se puede crear una capa del tipo &apos;%1&apos;.</translation>
+    </message>
+    <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>La versión de MapMap %1 usada para guardar este archivo no se puede leer con esta versión de MapMap %2.</translation>
+        <translation type="vanished">La versión de MapMap %1 usada para guardar este archivo no se puede leer con esta versión de MapMap %2.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="156"/>
         <source>Problem at creation of paint.</source>
-        <translation>Problema al crear la pintura.</translation>
+        <translation type="vanished">Problema al crear la pintura.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="187"/>
         <source>Problem at creation of mapping.</source>
-        <translation>Problema al crear el mapeo.</translation>
+        <translation type="vanished">Problema al crear el mapeo.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="44"/>
-        <location filename="../src/gui/PaintGui.cpp" line="38"/>
+        <location filename="../src/gui/LayerGui.cpp" line="44"/>
+        <location filename="../src/gui/SourceGui.cpp" line="42"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="50"/>
-        <location filename="../src/gui/PaintGui.cpp" line="44"/>
+        <location filename="../src/gui/LayerGui.cpp" line="50"/>
+        <location filename="../src/gui/SourceGui.cpp" line="48"/>
         <source>Opacity (%)</source>
         <translation>Opacidad (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="63"/>
+        <location filename="../src/gui/LayerGui.cpp" line="63"/>
         <source>Output shape</source>
         <translation>Forma de salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="150"/>
+        <location filename="../src/gui/LayerGui.cpp" line="151"/>
         <source>Point %1</source>
         <translation>Punto %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="194"/>
+        <location filename="../src/gui/LayerGui.cpp" line="195"/>
         <source>Mesh Subdivisions</source>
         <translation>Subdivisiones de la malla</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="423"/>
+        <location filename="../src/gui/LayerGui.cpp" line="424"/>
         <source>Subdivisions</source>
         <translation>Subdivisiones</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="288"/>
+        <location filename="../src/gui/LayerGui.cpp" line="289"/>
         <source>Input shape</source>
         <translation>Forma de entrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="88"/>
+        <location filename="../src/gui/SourceGui.cpp" line="92"/>
         <source>Color</source>
         <translation>Color</translation>
     </message>
@@ -326,12 +375,12 @@ Line %2, column %3</source>
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2523"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2521"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2543"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2541"/>
         <source>Select Font</source>
         <translation>Seleccionar fuente tipográfica</translation>
     </message>
@@ -596,54 +645,78 @@ Line %2, column %3</source>
         <translation>Acerca de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="82"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="93"/>
         <source>MapMap is a free/open source video mapping software.</source>
         <translation>MapMap es un software libre y de código abierto de mapeo de vídeo (video mapping).</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="84"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
         <translation>Derechos de autor &amp;copy; 2013 %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="94"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>See the </source>
         <translation>Consulte el </translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="108"/>
         <source>%1 website</source>
         <translation>sitio web de %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="111"/>
+        <source>%1 is developed and sponsored by Art Plus Code. Need a custom video mapping installation, a new feature, integration or training? </source>
+        <translation>%1 es desarrollado y patrocinado por Art Plus Code. ¿Necesita una instalación de mapeo de vídeo a medida, una nueva funcionalidad, integración o formación? </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="114"/>
+        <source>Hire us</source>
+        <translation>Contrátenos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="115"/>
+        <source>Enjoying %1? </source>
+        <translation>¿Le gusta %1? </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="116"/>
+        <source>Support the project</source>
+        <translation>Apoyar el proyecto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="132"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="119"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="144"/>
         <source>Changelog</source>
         <translation>Registro de cambios</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="137"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="159"/>
         <source>Libraries</source>
         <translation>Bibliotecas</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="149"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="170"/>
         <source>Contributors</source>
         <translation>Colaboradores</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="161"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="183"/>
         <source>License</source>
         <translation>Licencia</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="173"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="196"/>
+        <source>OSC Commands</source>
+        <translation>Comandos OSC</translation>
+    </message>
+    <message>
         <source>OSC</source>
-        <translation>OSC</translation>
+        <translation type="vanished">OSC</translation>
     </message>
 </context>
 <context>
@@ -669,7 +742,7 @@ Line %2, column %3</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/ConsoleWindow.cpp" line="101"/>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="104"/>
         <source>MMM dd yy HH:mm</source>
         <translation>MMM dd yy HH:mm</translation>
     </message>
@@ -677,718 +750,850 @@ Line %2, column %3</source>
 <context>
     <name>mmp::ImageGui</name>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="122"/>
+        <location filename="../src/gui/SourceGui.cpp" line="126"/>
         <source>Image file</source>
         <translation>Archivo de imagen</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="124"/>
+        <location filename="../src/gui/SourceGui.cpp" line="128"/>
         <source>Image files (%1);;All files (*)</source>
         <translation>Archivos de imagen (%1);;Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="128"/>
+        <location filename="../src/gui/SourceGui.cpp" line="132"/>
         <source>Speed (%)</source>
         <translation>Velocidad (%)</translation>
     </message>
 </context>
 <context>
+    <name>mmp::LayerItemDelegate</name>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="100"/>
+        <source>Solo mapping</source>
+        <translation>Mapeo en solo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="112"/>
+        <source>Lock mapping</source>
+        <translation>Bloquear mapeo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="124"/>
+        <source>Duplicate mapping</source>
+        <translation>Duplicar mapeo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="136"/>
+        <source>Delete mapping</source>
+        <translation>Eliminar mapeo</translation>
+    </message>
+</context>
+<context>
     <name>mmp::MainWindow</name>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="525"/>
-        <location filename="../src/gui/MainWindow.cpp" line="531"/>
+        <location filename="../src/gui/MainWindow.cpp" line="548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="554"/>
         <source>Open project</source>
         <translation>Abrir proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="527"/>
-        <location filename="../src/gui/MainWindow.cpp" line="533"/>
-        <location filename="../src/gui/MainWindow.cpp" line="565"/>
-        <location filename="../src/gui/MainWindow.cpp" line="571"/>
+        <location filename="../src/gui/MainWindow.cpp" line="550"/>
+        <location filename="../src/gui/MainWindow.cpp" line="556"/>
+        <location filename="../src/gui/MainWindow.cpp" line="588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="594"/>
         <source>MapMap files (*.%1)</source>
         <translation>Archivos de MapMap (*.%1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="564"/>
-        <location filename="../src/gui/MainWindow.cpp" line="570"/>
+        <location filename="../src/gui/MainWindow.cpp" line="587"/>
+        <location filename="../src/gui/MainWindow.cpp" line="593"/>
         <source>Save project</source>
         <translation>Guardar proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="601"/>
-        <location filename="../src/gui/MainWindow.cpp" line="609"/>
+        <location filename="../src/gui/MainWindow.cpp" line="624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="632"/>
         <source>Import media source file</source>
         <translation>Importar archivo de fuente multimedia</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="611"/>
+        <location filename="../src/gui/MainWindow.cpp" line="626"/>
+        <location filename="../src/gui/MainWindow.cpp" line="634"/>
         <source>Media files (%1 %2);;All files (*)</source>
         <translation>Archivos multimedia (%1 %2);;Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="646"/>
+        <location filename="../src/gui/MainWindow.cpp" line="672"/>
         <source>Camera device</source>
         <translation>Dispositivo de cámara</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="647"/>
+        <location filename="../src/gui/MainWindow.cpp" line="673"/>
         <source>Select camera</source>
         <translation>Seleccionar cámara</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>No camera available</source>
         <translation>No hay cámara disponible</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>You can not use this feature!
 No camera available in your system</source>
         <translation>No hay cámara disponible</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="684"/>
-        <location filename="../src/gui/MainWindow.cpp" line="688"/>
+        <location filename="../src/gui/MainWindow.cpp" line="717"/>
+        <location filename="../src/gui/MainWindow.cpp" line="721"/>
         <source>Select Color</source>
         <translation>Seleccionar color</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1449"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1605"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2453"/>
+        <location filename="../src/gui/MainWindow.cpp" line="755"/>
+        <source>Syphon source added</source>
+        <translation>Fuente Syphon añadida</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1620"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1781"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2769"/>
         <source>MapMap</source>
         <translation>MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1619"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1795"/>
         <source>&amp;New</source>
         <translation>&amp;Nuevo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1622"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1798"/>
         <source>Create a new project</source>
         <translation>Crear un nuevo proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1805"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1632"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1808"/>
         <source>Open an existing project</source>
         <translation>Abrir un proyecto existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1639"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1815"/>
         <source>&amp;Save</source>
         <translation>&amp;Guardar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1642"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1818"/>
         <source>Save the project</source>
         <translation>Guardar el proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1649"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1825"/>
         <source>Save &amp;As...</source>
         <translation>Guardar &amp;como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1652"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Save the project as...</source>
         <translation>Guardar el proyecto como...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1681"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1857"/>
         <source>No Recents Videos</source>
         <translation>No hay vídeos recientes</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1686"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1862"/>
         <source>&amp;Import Media File...</source>
         <translation>&amp;Importar archivo multimedia...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1689"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Import a video or image file...</source>
         <translation>Importar un archivo de vídeo o imagen...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1697"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1872"/>
         <source>Open &amp;Camera Device...</source>
         <translation>Abrir dispositivo de &amp;cámara...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1701"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Choose your camera device...</source>
         <translation>Elija su dispositivo de cámara...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1711"/>
         <source>Add a color paint...</source>
-        <translation>Añadir una pintura de color...</translation>
+        <translation type="vanished">Añadir una pintura de color...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1718"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1904"/>
         <source>E&amp;xit</source>
         <translation>S&amp;alir</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1720"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1906"/>
         <source>Exit the application</source>
         <translation>Salir de la aplicación</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>&amp;Undo</source>
         <translation>&amp;Deshacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1734"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1920"/>
         <source>&amp;Redo</source>
         <translation>&amp;Rehacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1741"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1927"/>
         <source>&amp;About MapMap</source>
         <translation>&amp;Acerca de MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1742"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1928"/>
         <source>Show the application&apos;s About box</source>
         <translation>Mostrar el cuadro Acerca de de la aplicación</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1855"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1988"/>
+        <source>Solo layer item</source>
+        <translation>Elemento de capa en solo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1998"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1999"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2006"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <source>Rotate 90° CW</source>
+        <translation>Rotar 90° en sentido horario</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2014"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2015"/>
+        <source>Rotate 180°</source>
+        <translation>Rotar 180°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2099"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Preferencias...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1858"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2102"/>
         <source>Configure preferences...</source>
         <translation>Configurar preferencias...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1899"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1902"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2143"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2146"/>
         <source>Play</source>
         <translation>Reproducir</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1910"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2157"/>
         <source>Pause</source>
         <translation>Pausa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1931"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2175"/>
         <source>Toggle &amp;Fullscreen</source>
         <translation>Alternar &amp;pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1934"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2178"/>
         <source>Toggle Fullscreen</source>
         <translation>Alternar pantalla completa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1952"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2197"/>
         <source>&amp;Display Controls</source>
         <translation>&amp;Mostrar controles</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2200"/>
         <source>Display canvas controls</source>
         <translation>Mostrar los controles del lienzo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1981"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2226"/>
         <source>&amp;Sticky Vertices</source>
         <translation>&amp;Vértices magnéticos</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1984"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2229"/>
         <source>Enable sticky vertices</source>
         <translation>Activar vértices magnéticos</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1993"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2238"/>
         <source>Show &amp;Test Signal</source>
         <translation>Mostrar señal de &amp;prueba</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1996"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2241"/>
         <source>Show Test signal</source>
         <translation>Mostrar señal de prueba</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2270"/>
         <source>Display &amp;Undo History</source>
         <translation>Mostrar &amp;historial de deshacer</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2017"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2280"/>
         <source>Open Conso&amp;le</source>
         <translation>Abrir conso&amp;la</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2028"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2291"/>
         <source>Display &amp;Zoom Toolbar</source>
         <translation>Mostrar barra de &amp;zoom</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2038"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2301"/>
         <source>&amp;Menu Bar</source>
         <translation>Barra de &amp;menús</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2045"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>Main Layout</source>
         <translation>Disposición principal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2312"/>
         <source>Switch to the Main layout.</source>
         <translation>Cambiar a la disposición principal.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1450"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1621"/>
         <source>Remove this source and all its associated layers?</source>
         <translation>¿Quitar esta fuente y todas sus capas asociadas?</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1693"/>
         <source>Input Editor</source>
         <translation>Editor de entrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1537"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1709"/>
         <source>Output Editor</source>
         <translation>Editor de salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1583"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1758"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1584"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Layers</source>
         <translation>Capas</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1708"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1882"/>
         <source>Add &amp;Color Source...</source>
         <translation>Añadir fuente de &amp;color...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1749"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1885"/>
+        <source>Add a color source...</source>
+        <translation>Añadir una fuente de color...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1893"/>
+        <source>Add &amp;Syphon Source...</source>
+        <translation>Añadir fuente &amp;Syphon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1896"/>
+        <source>Receive live video from another application via Syphon...</source>
+        <translation>Recibir vídeo en directo de otra aplicación mediante Syphon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1935"/>
         <source>Duplicate Layer</source>
         <translation>Duplicar capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1751"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1937"/>
         <source>Duplicate layer item</source>
         <translation>Duplicar elemento de capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1945"/>
         <source>Delete Layer</source>
         <translation>Eliminar capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1761"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1947"/>
         <source>Delete layer item</source>
         <translation>Eliminar elemento de capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1769"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Rename Layer</source>
         <translation>Renombrar capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1771"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1957"/>
         <source>Rename layer item</source>
         <translation>Renombrar elemento de capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1965"/>
         <source>Lock Layer</source>
         <translation>Bloquear capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1780"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>Lock layer item</source>
         <translation>Bloquear elemento de capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1790"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1976"/>
         <source>Hide Layer</source>
         <translation>Ocultar capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1791"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1977"/>
         <source>Hide layer item</source>
         <translation>Ocultar elemento de capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1801"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1987"/>
         <source>Solo Layer</source>
         <translation>Capa en solo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1802"/>
         <source>solo layer item</source>
-        <translation>elemento de capa en solo</translation>
+        <translation type="vanished">elemento de capa en solo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1812"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1813"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2022"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2024"/>
         <source>Flip Horizontally</source>
         <translation>Voltear horizontalmente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1820"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1821"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2031"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2033"/>
         <source>Flip Vertically</source>
         <translation>Voltear verticalmente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2039"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2041"/>
+        <source>Raise</source>
+        <translation>Subir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2047"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <source>Lower</source>
+        <translation>Bajar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2055"/>
+        <source>Raise to Top</source>
+        <translation>Subir hasta arriba</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2057"/>
+        <source>Raise to top</source>
+        <translation>Subir hasta arriba</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <source>Lower to Bottom</source>
+        <translation>Bajar hasta el fondo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2065"/>
+        <source>Lower to bottom</source>
+        <translation>Bajar hasta el fondo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2072"/>
         <source>Delete Source</source>
         <translation>Eliminar fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1830"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
         <source>Delete source item</source>
         <translation>Eliminar elemento de fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1838"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2082"/>
         <source>Rename Source</source>
         <translation>Renombrar fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1840"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2084"/>
         <source>Rename source item</source>
         <translation>Renombrar elemento de fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1848"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2092"/>
         <source>Import New Media</source>
         <translation>Importar nuevo archivo multimedia</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1849"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2093"/>
         <source>Import new media file if not exists on the list</source>
         <translation>Importar un nuevo archivo multimedia si no está en la lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
         <source>Add &amp;Mesh Layer</source>
         <translation>Añadir capa de &amp;malla</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1868"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
         <source>Add mesh layer</source>
         <translation>Añadir capa de malla</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2120"/>
         <source>Add &amp;Triangle Layer</source>
         <translation>Añadir capa de &amp;triángulo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1879"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2123"/>
         <source>Add triangle layer</source>
         <translation>Añadir capa de triángulo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1887"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2131"/>
         <source>Add &amp;Ellipse Layer</source>
         <translation>Añadir capa de &amp;elipse</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1890"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2134"/>
         <source>Add ellipse layer</source>
         <translation>Añadir capa de elipse</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1921"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1924"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2165"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2168"/>
         <source>Restart</source>
         <translation>Reiniciar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2211"/>
         <source>&amp;Display Controls of Layers of a Source</source>
         <translation>&amp;Mostrar controles de las capas de una fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1969"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2214"/>
         <source>Display all canvas controls related to current source</source>
         <translation>Mostrar todos los controles del lienzo relacionados con la fuente actual</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2053"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2254"/>
+        <source>&amp;Publish Syphon Output</source>
+        <translation>&amp;Publicar la salida Syphon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2255"/>
+        <source>Publish the output composition as a Syphon server other apps can receive</source>
+        <translation>Publicar la composición de salida como un servidor Syphon que otras aplicaciones pueden recibir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2316"/>
         <source>Input editor Layout</source>
         <translation>Disposición del editor de entrada</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2056"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2319"/>
         <source>Switch to the Input editor Layout.</source>
         <translation>Cambiar a la disposición del editor de entrada.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2060"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2323"/>
         <source>Output Editor Layout</source>
         <translation>Disposición del editor de salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2326"/>
         <source>Switch to the Output Editors Layout.</source>
         <translation>Cambiar a la disposición del editor de salida.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2076"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2337"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2339"/>
         <source>Zoom In</source>
         <translation>Acercar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2081"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2083"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2344"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2346"/>
         <source>Zoom Out</source>
         <translation>Alejar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2088"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2351"/>
         <source>Original Size</source>
         <translation>Tamaño original</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2090"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2353"/>
         <source>Reset zoom to original size</source>
         <translation>Restablecer el zoom al tamaño original</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2358"/>
         <source>Fit To View</source>
         <translation>Ajustar a la vista</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2096"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2359"/>
         <source>Fit to viewport</source>
         <translation>Ajustar a la ventana gráfica</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2103"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2366"/>
         <source>Report an issue</source>
         <translation>Informar de un problema</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2106"/>
         <source>Technical support</source>
-        <translation>Soporte técnico</translation>
+        <translation type="vanished">Soporte técnico</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2369"/>
+        <source>Professional services &amp;&amp; custom development…</source>
+        <translation>Servicios profesionales &amp;&amp; desarrollo a medida…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2370"/>
+        <source>Hire Art Plus Code for video mapping installations, custom features, integration and training</source>
+        <translation>Contrate a Art Plus Code para instalaciones de mapeo de vídeo, funcionalidades a medida, integración y formación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2373"/>
+        <source>Support the project (donate)…</source>
+        <translation>Apoyar el proyecto (donar)…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2374"/>
+        <source>Help fund MapMap&apos;s ongoing development</source>
+        <translation>Ayude a financiar el desarrollo continuo de MapMap</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2377"/>
         <source>Documentation</source>
         <translation>Documentación</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2380"/>
         <source>Submit feedback via email</source>
         <translation>Enviar comentarios por correo electrónico</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2383"/>
+        <source>&amp;Keyboard shortcuts</source>
+        <translation>Atajos de &amp;teclado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2412"/>
         <source>&amp;File</source>
         <translation>&amp;Archivo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2427"/>
         <source>Open Recents Projects</source>
         <translation>Abrir proyectos recientes</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2161"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2434"/>
         <source>Open Recents Videos</source>
         <translation>Abrir vídeos recientes</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2172"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2445"/>
         <source>&amp;Edit</source>
         <translation>&amp;Editar</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2196"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2484"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2207"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>&amp;Output screen</source>
         <translation>Pantalla de &amp;salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2216"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2507"/>
         <source>&amp;Window</source>
         <translation>Ve&amp;ntana</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2240"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2531"/>
         <source>&amp;Help</source>
         <translation>A&amp;yuda</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2268"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2560"/>
         <source>Change Layer Source</source>
         <translation>Cambiar la fuente de la capa</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2614"/>
         <source>&amp;Toolbar</source>
         <translation>Barra de &amp;herramientas</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2454"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2770"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
         <translation>Barra de &amp;herramientas</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2476"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2490"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2792"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2806"/>
         <source>Error reading mapping project file</source>
         <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2477"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2793"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3062"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2491"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2807"/>
         <source>Parse error in file %1:
 
 %2</source>
         <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2814"/>
         <source>File loaded</source>
         <translation>Archivo cargado</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2510"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2843"/>
         <source>Error saving mapping project</source>
         <translation>Error al guardar el proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2511"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2829"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Error al guardar el proyecto</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2844"/>
+        <source>Cannot rename temporary file to %1.</source>
+        <translation>No se puede renombrar el archivo temporal a %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2849"/>
         <source>File saved</source>
         <translation>Archivo guardado</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2865"/>
         <source>Untitled</source>
         <translation>Sin título</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
         <source>%1[*] - %2</source>
         <translation>%1[*] - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2726"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3061"/>
         <source>MapMap Project</source>
         <translation>Proyecto de MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2571"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2657"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2903"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2935"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2989"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2920"/>
         <source>Clear List</source>
         <translation>Vaciar lista</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2591"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2923"/>
         <source>No Recents Projects</source>
         <translation>No hay proyectos recientes</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2956"/>
         <source>%1 - %2x%3</source>
         <translation>%1 - %2x%3</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2961"/>
         <source> - Primary</source>
         <translation> - Principal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2758"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>File imported</source>
         <translation>Archivo importado</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3115"/>
         <source>Color source added</source>
         <translation>Fuente de color añadida</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3497"/>
         <source>Warning</source>
         <translation>Advertencia</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3498"/>
         <source>The following file is not supported: %1</source>
         <translation>El siguiente archivo no es compatible: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3122"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3525"/>
         <source>Cannot load movie</source>
         <translation>No se puede cargar el vídeo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3123"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3526"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
         <translation>No se puede cargar el vídeo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3130"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3138"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3541"/>
         <source>Locate file %1</source>
         <translation>Localizar el archivo %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3132"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3535"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3543"/>
         <source>%1 files (%2)</source>
         <translation>Archivos %1 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3265"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3668"/>
         <source>Undo history</source>
         <translation>Historial de deshacer</translation>
     </message>
@@ -1396,22 +1601,22 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MapperGLCanvasToolbar</name>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="54"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="58"/>
         <source>Enlarge the shape</source>
         <translation>Agrandar la forma</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="62"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="66"/>
         <source>Shrink the shape</source>
         <translation>Encoger la forma</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="70"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="74"/>
         <source>Reset the shape to the normal size</source>
         <translation>Restablecer la forma a su tamaño normal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="78"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="82"/>
         <source>Fit the shape to content view</source>
         <translation>Ajustar la forma a la vista</translation>
     </message>
@@ -1419,37 +1624,44 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MappingItemDelegate</name>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="99"/>
         <source>Solo mapping</source>
-        <translation>Mapeo en solo</translation>
+        <translation type="vanished">Mapeo en solo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="111"/>
         <source>Lock mapping</source>
-        <translation>Bloquear mapeo</translation>
+        <translation type="vanished">Bloquear mapeo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="123"/>
         <source>Duplicate mapping</source>
-        <translation>Duplicar mapeo</translation>
+        <translation type="vanished">Duplicar mapeo</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="135"/>
         <source>Delete mapping</source>
-        <translation>Eliminar mapeo</translation>
+        <translation type="vanished">Eliminar mapeo</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::MeshTextureLayerGui</name>
+    <message>
+        <location filename="../src/gui/LayerGui.cpp" line="428"/>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerGui.cpp" line="429"/>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
     </message>
 </context>
 <context>
     <name>mmp::MeshTextureMappingGui</name>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="427"/>
         <source>Horizontal</source>
-        <translation>Horizontal</translation>
+        <translation type="vanished">Horizontal</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="428"/>
         <source>Vertical</source>
-        <translation>Vertical</translation>
+        <translation type="vanished">Vertical</translation>
     </message>
 </context>
 <context>
@@ -1460,165 +1672,302 @@ The original file is not found. Please locate.</source>
         <translation>Preferencias</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="182"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="201"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="183"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="202"/>
         <source>Medium</source>
         <translation>Mediano</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="184"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="203"/>
         <source>Small</source>
         <translation>Pequeño</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="188"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Language (requires restart)</source>
         <translation>Idioma (requiere reiniciar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="192"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="211"/>
         <source>Toolbar icon size (requires restart)</source>
         <translation>Tamaño de los iconos de la barra de herramientas (requiere reiniciar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="226"/>
         <source>Enable Sticky vertices</source>
         <translation>Activar vértices magnéticos</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="220"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="239"/>
         <source>Sensitivity</source>
         <translation>Sensibilidad</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="222"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="241"/>
         <source>Vertices</source>
         <translation>Vértices</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="248"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="267"/>
         <source>Only show output controls on mouse over</source>
         <translation>Mostrar los controles de salida solo al pasar el ratón</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="253"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="272"/>
         <source>Output Layers</source>
         <translation>Capas de salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="257"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="276"/>
         <source>Show resolution on output test cards</source>
         <translation>Mostrar la resolución en las cartas de ajuste de salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="259"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="278"/>
         <source>Classic test card</source>
         <translation>Carta de ajuste clásica</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="260"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="279"/>
         <source>PAL test card</source>
         <translation>Carta de ajuste PAL</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="261"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="280"/>
         <source>NTSC test card</source>
         <translation>Carta de ajuste NTSC</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="290"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="309"/>
         <source>Test Card</source>
         <translation>Carta de ajuste</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="337"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="356"/>
         <source>Listen to OSC messages</source>
         <translation>Escuchar mensajes OSC</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="344"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="363"/>
         <source>Allow message with existing media source</source>
         <translation>Permitir mensaje con fuente multimedia existente</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="349"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="366"/>
+        <source>Accept OSC from the network (less secure)</source>
+        <translation>Aceptar OSC desde la red (menos seguro)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="368"/>
+        <source>When off, OSC is only reachable from this computer (127.0.0.1). Enable only on a trusted show network — OSC has no authentication.</source>
+        <translation>Cuando está desactivado, OSC solo es accesible desde este ordenador (127.0.0.1). Actívelo solo en una red de espectáculo de confianza — OSC no tiene autenticación.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="371"/>
+        <source>Allow OSC to quit the application</source>
+        <translation>Permitir que OSC cierre la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="373"/>
+        <source>When off, the /mapmap/quit OSC command is ignored so a remote sender cannot close the application during a show.</source>
+        <translation>Cuando está desactivado, el comando OSC /mapmap/quit se ignora para que un emisor remoto no pueda cerrar la aplicación durante un espectáculo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="378"/>
         <source>on port</source>
         <translation>en el puerto</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="352"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="381"/>
         <source>Refresh</source>
         <translation>Actualizar</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="362"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="391"/>
         <source>Local IP</source>
         <translation>IP local</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="374"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="405"/>
         <source>OSC Setup</source>
         <translation>Configuración de OSC</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="387"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="414"/>
+        <source>Disabled</source>
+        <translation>Desactivado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="418"/>
+        <source>MCP port (0 to disable)</source>
+        <translation>Puerto MCP (0 para desactivar)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="426"/>
+        <source>MCP Setup</source>
+        <translation>Configuración de MCP</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="440"/>
         <source>Play in loop (requires restart)</source>
         <translation>Reproducir en bucle (requiere reiniciar)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="395"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="448"/>
         <source>Playback</source>
         <translation>Reproducción</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="401"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="454"/>
         <source>Interface</source>
         <translation>Interfaz</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="404"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="457"/>
         <source>Layers</source>
         <translation>Capas</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="407"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="460"/>
         <source>Output</source>
         <translation>Salida</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="410"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="463"/>
         <source>Controls</source>
         <translation>Controles</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="413"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="466"/>
         <source>Advanced</source>
         <translation>Avanzado</translation>
     </message>
 </context>
 <context>
+    <name>mmp::ShortcutWindow</name>
+    <message>
+        <location filename="../src/gui/ShortcutWindow.cpp" line="36"/>
+        <source>%1 - Keyboard Shortcuts</source>
+        <translation>%1 - Atajos de teclado</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonGui</name>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="254"/>
+        <source>Server</source>
+        <translation>Servidor</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="255"/>
+        <source>Status</source>
+        <translation>Estado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="257"/>
+        <source>Respect source alpha</source>
+        <translation>Respetar el alfa de la fuente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="304"/>
+        <source>(none)</source>
+        <translation>(ninguno)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="310"/>
+        <source>Unknown server</source>
+        <translation>Servidor desconocido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="326"/>
+        <source>Connected</source>
+        <translation>Conectado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="330"/>
+        <source>No server selected</source>
+        <translation>Ningún servidor seleccionado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="332"/>
+        <source>Waiting for server…</source>
+        <translation>Esperando al servidor…</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonServerDialog</name>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="41"/>
+        <source>Add Syphon Source</source>
+        <translation>Añadir fuente Syphon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="46"/>
+        <source>Choose a Syphon server to receive video from:</source>
+        <translation>Elija un servidor Syphon del que recibir vídeo:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="86"/>
+        <source>(Create without connecting yet)</source>
+        <translation>(Crear sin conectar todavía)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="91"/>
+        <source>Unknown server</source>
+        <translation>Servidor desconocido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="99"/>
+        <source>Application: %1</source>
+        <translation>Aplicación: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="100"/>
+        <source>Server: %1</source>
+        <translation>Servidor: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="101"/>
+        <source>ID: %1</source>
+        <translation>ID: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="107"/>
+        <source>No Syphon servers found yet. Open a Syphon-enabled app (Resolume, VDMX, a Simple Server, …), or create the source now and connect it later.</source>
+        <translation>Aún no se han encontrado servidores Syphon. Abra una aplicación compatible con Syphon (Resolume, VDMX, un Simple Server, …), o cree la fuente ahora y conéctela más tarde.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="111"/>
+        <source>%n Syphon server(s) available. The list updates automatically.</source>
+        <translation>
+            <numerusform>%n servidor Syphon disponible. La lista se actualiza automáticamente.</numerusform>
+            <numerusform>%n servidores Syphon disponibles. La lista se actualiza automáticamente.</numerusform>
+        </translation>
+    </message>
+</context>
+<context>
     <name>mmp::VideoGui</name>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="170"/>
+        <location filename="../src/gui/SourceGui.cpp" line="174"/>
         <source>Source</source>
         <translation>Fuente</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="172"/>
+        <location filename="../src/gui/SourceGui.cpp" line="176"/>
         <source>Video files (%1);;All files (*)</source>
         <translation>Archivos de vídeo (%1);;Todos los archivos (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="176"/>
+        <location filename="../src/gui/SourceGui.cpp" line="180"/>
         <source>Speed (%)</source>
         <translation>Velocidad (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="183"/>
+        <location filename="../src/gui/SourceGui.cpp" line="187"/>
         <source>Volume (%)</source>
         <translation>Volumen (%)</translation>
     </message>

--- a/translations/mapmap_es.ts
+++ b/translations/mapmap_es.ts
@@ -875,8 +875,8 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1805"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;Abrir...</translation>
+        <source>&amp;Open…</source>
+        <translation>&amp;Abrir…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1808"/>
@@ -895,13 +895,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1825"/>
-        <source>Save &amp;As...</source>
-        <translation>Guardar &amp;como...</translation>
+        <source>Save &amp;As…</source>
+        <translation>Guardar &amp;como…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Save the project as...</source>
-        <translation>Guardar el proyecto como...</translation>
+        <source>Save the project as…</source>
+        <translation>Guardar el proyecto como…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1857"/>
@@ -910,23 +910,23 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1862"/>
-        <source>&amp;Import Media File...</source>
-        <translation>&amp;Importar archivo multimedia...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation>&amp;Importar archivo multimedia…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Import a video or image file...</source>
-        <translation>Importar un archivo de vídeo o imagen...</translation>
+        <source>Import a video or image file…</source>
+        <translation>Importar un archivo de vídeo o imagen…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1872"/>
-        <source>Open &amp;Camera Device...</source>
-        <translation>Abrir dispositivo de &amp;cámara...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation>Abrir dispositivo de &amp;cámara…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Choose your camera device...</source>
-        <translation>Elija su dispositivo de cámara...</translation>
+        <source>Choose your camera device…</source>
+        <translation>Elija su dispositivo de cámara…</translation>
     </message>
     <message>
         <source>Add a color paint...</source>
@@ -983,13 +983,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2099"/>
-        <source>&amp;Preferences...</source>
-        <translation>&amp;Preferencias...</translation>
+        <source>&amp;Preferences…</source>
+        <translation>&amp;Preferencias…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2102"/>
-        <source>Configure preferences...</source>
-        <translation>Configurar preferencias...</translation>
+        <source>Configure preferences…</source>
+        <translation>Configurar preferencias…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2143"/>
@@ -1100,23 +1100,23 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1882"/>
-        <source>Add &amp;Color Source...</source>
-        <translation>Añadir fuente de &amp;color...</translation>
+        <source>Add &amp;Color Source…</source>
+        <translation>Añadir fuente de &amp;color…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1885"/>
-        <source>Add a color source...</source>
-        <translation>Añadir una fuente de color...</translation>
+        <source>Add a color source…</source>
+        <translation>Añadir una fuente de color…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1893"/>
-        <source>Add &amp;Syphon Source...</source>
-        <translation>Añadir fuente &amp;Syphon...</translation>
+        <source>Add &amp;Syphon Source…</source>
+        <translation>Añadir fuente &amp;Syphon…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1896"/>
-        <source>Receive live video from another application via Syphon...</source>
-        <translation>Recibir vídeo en directo de otra aplicación mediante Syphon...</translation>
+        <source>Receive live video from another application via Syphon…</source>
+        <translation>Recibir vídeo en directo de otra aplicación mediante Syphon…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1935"/>

--- a/translations/mapmap_es.ts
+++ b/translations/mapmap_es.ts
@@ -6,7 +6,7 @@
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="54"/>
         <source>Choose a file</source>
-        <translation type="unfinished">Seleccionar archivo</translation>
+        <translation>Elegir un archivo</translation>
     </message>
 </context>
 <context>
@@ -14,147 +14,147 @@
     <message>
         <location filename="../src/app/main.cpp" line="185"/>
         <source>Initiating program...</source>
-        <translation type="unfinished"></translation>
+        <translation>Iniciando el programa...</translation>
     </message>
     <message>
         <location filename="../src/app/main.cpp" line="240"/>
         <source>Done.</source>
-        <translation type="unfinished"></translation>
+        <translation>Listo.</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="36"/>
         <source>Add source</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir fuente</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="62"/>
         <source>Add layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="87"/>
         <source>Duplicate layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar capa</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="144"/>
         <source>Move vertex</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover el vértice</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="190"/>
         <source>Rotate shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Rotar la forma</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Scale shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Escalar la forma</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="231"/>
         <source>Move shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Mover la forma</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="261"/>
         <source>Remove media</source>
-        <translation type="unfinished"></translation>
+        <translation>Quitar multimedia</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="299"/>
         <source>Delete layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar capa</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="329"/>
         <source>Flipped Horizontally</source>
-        <translation type="unfinished"></translation>
+        <translation>Volteado horizontalmente</translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="334"/>
         <source>Flipped Vertically</source>
-        <translation type="unfinished"></translation>
+        <translation>Volteado verticalmente</translation>
     </message>
     <message>
         <location filename="../src/core/Mapping.cpp" line="154"/>
         <source>Problem at creation of shape.</source>
-        <translation type="unfinished"></translation>
+        <translation>Problema al crear la forma.</translation>
     </message>
     <message>
         <location filename="../src/core/Mapping.cpp" line="170"/>
         <location filename="../src/core/ProjectReader.cpp" line="169"/>
         <location filename="../src/core/ProjectReader.cpp" line="198"/>
         <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se puede crear una pintura del tipo &apos;%1&apos;.</translation>
     </message>
     <message>
         <location filename="../src/core/ProjectReader.cpp" line="56"/>
         <source>The contents of this file does not look like a MapMap project.</source>
-        <translation type="unfinished"></translation>
+        <translation>El contenido de este archivo no parece un proyecto de MapMap.</translation>
     </message>
     <message>
         <location filename="../src/core/ProjectReader.cpp" line="60"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>La versión de MapMap %1 usada para guardar este archivo no se puede leer con esta versión de MapMap %2.</translation>
     </message>
     <message>
         <location filename="../src/core/ProjectReader.cpp" line="72"/>
         <source>%1
 Line %2, column %3</source>
-        <translation type="unfinished"></translation>
+        <translation>La versión de MapMap %1 usada para guardar este archivo no se puede leer con esta versión de MapMap %2.</translation>
     </message>
     <message>
         <location filename="../src/core/ProjectReader.cpp" line="156"/>
         <source>Problem at creation of paint.</source>
-        <translation type="unfinished"></translation>
+        <translation>Problema al crear la pintura.</translation>
     </message>
     <message>
         <location filename="../src/core/ProjectReader.cpp" line="187"/>
         <source>Problem at creation of mapping.</source>
-        <translation type="unfinished"></translation>
+        <translation>Problema al crear el mapeo.</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="44"/>
         <location filename="../src/gui/PaintGui.cpp" line="38"/>
         <source>ID</source>
-        <translation type="unfinished"></translation>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="50"/>
         <location filename="../src/gui/PaintGui.cpp" line="44"/>
         <source>Opacity (%)</source>
-        <translation type="unfinished"></translation>
+        <translation>Opacidad (%)</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="63"/>
         <source>Output shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Forma de salida</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="150"/>
         <source>Point %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Punto %1</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="194"/>
         <source>Mesh Subdivisions</source>
-        <translation type="unfinished"></translation>
+        <translation>Subdivisiones de la malla</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="423"/>
         <source>Subdivisions</source>
-        <translation type="unfinished"></translation>
+        <translation>Subdivisiones</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="288"/>
         <source>Input shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Forma de entrada</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="88"/>
         <source>Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Color</translation>
     </message>
 </context>
 <context>
@@ -164,13 +164,13 @@ Line %2, column %3</source>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>True</source>
-        <translation type="unfinished"></translation>
+        <translation>Verdadero</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>False</source>
-        <translation type="unfinished"></translation>
+        <translation>Falso</translation>
     </message>
 </context>
 <context>
@@ -178,12 +178,12 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="1696"/>
         <source>True</source>
-        <translation type="unfinished"></translation>
+        <translation>Verdadero</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="1697"/>
         <source>False</source>
-        <translation type="unfinished"></translation>
+        <translation>Falso</translation>
     </message>
 </context>
 <context>
@@ -191,7 +191,7 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="1700"/>
         <source>Clear Char</source>
-        <translation type="unfinished"></translation>
+        <translation>Borrar carácter</translation>
     </message>
 </context>
 <context>
@@ -199,7 +199,7 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2314"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
 </context>
 <context>
@@ -207,22 +207,22 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6421"/>
         <source>Red</source>
-        <translation type="unfinished"></translation>
+        <translation>Rojo</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6429"/>
         <source>Green</source>
-        <translation type="unfinished"></translation>
+        <translation>Verde</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6437"/>
         <source>Blue</source>
-        <translation type="unfinished"></translation>
+        <translation>Azul</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6445"/>
         <source>Alpha</source>
-        <translation type="unfinished"></translation>
+        <translation>Alfa</translation>
     </message>
 </context>
 <context>
@@ -230,97 +230,97 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="58"/>
         <source>Arrow</source>
-        <translation type="unfinished"></translation>
+        <translation>Flecha</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="60"/>
         <source>Up Arrow</source>
-        <translation type="unfinished"></translation>
+        <translation>Flecha arriba</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="62"/>
         <source>Cross</source>
-        <translation type="unfinished"></translation>
+        <translation>Cruz</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="64"/>
         <source>Wait</source>
-        <translation type="unfinished"></translation>
+        <translation>Espera</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="66"/>
         <source>IBeam</source>
-        <translation type="unfinished"></translation>
+        <translation>Cursor de texto</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="68"/>
         <source>Size Vertical</source>
-        <translation type="unfinished"></translation>
+        <translation>Redimensionar vertical</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="70"/>
         <source>Size Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation>Redimensionar horizontal</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="72"/>
         <source>Size Backslash</source>
-        <translation type="unfinished"></translation>
+        <translation>Redimensionar (barra invertida)</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="74"/>
         <source>Size Slash</source>
-        <translation type="unfinished"></translation>
+        <translation>Redimensionar (barra)</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="76"/>
         <source>Size All</source>
-        <translation type="unfinished"></translation>
+        <translation>Redimensionar en todas direcciones</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="78"/>
         <source>Blank</source>
-        <translation type="unfinished"></translation>
+        <translation>En blanco</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="80"/>
         <source>Split Vertical</source>
-        <translation type="unfinished"></translation>
+        <translation>Dividir verticalmente</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="82"/>
         <source>Split Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation>Dividir horizontalmente</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="84"/>
         <source>Pointing Hand</source>
-        <translation type="unfinished"></translation>
+        <translation>Mano señaladora</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="86"/>
         <source>Forbidden</source>
-        <translation type="unfinished"></translation>
+        <translation>Prohibido</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="88"/>
         <source>Open Hand</source>
-        <translation type="unfinished"></translation>
+        <translation>Mano abierta</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="90"/>
         <source>Closed Hand</source>
-        <translation type="unfinished"></translation>
+        <translation>Mano cerrada</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="92"/>
         <source>What&apos;s This</source>
-        <translation type="unfinished"></translation>
+        <translation>Qué es esto</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="94"/>
         <source>Busy</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocupado</translation>
     </message>
 </context>
 <context>
@@ -328,12 +328,12 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2523"/>
         <source>...</source>
-        <translation type="unfinished"></translation>
+        <translation>...</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2543"/>
         <source>Select Font</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar fuente tipográfica</translation>
     </message>
 </context>
 <context>
@@ -341,37 +341,37 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6095"/>
         <source>Family</source>
-        <translation type="unfinished"></translation>
+        <translation>Familia</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6108"/>
         <source>Point Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamaño en puntos</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6116"/>
         <source>Bold</source>
-        <translation type="unfinished"></translation>
+        <translation>Negrita</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6123"/>
         <source>Italic</source>
-        <translation type="unfinished"></translation>
+        <translation>Cursiva</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6130"/>
         <source>Underline</source>
-        <translation type="unfinished"></translation>
+        <translation>Subrayado</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6137"/>
         <source>Strikeout</source>
-        <translation type="unfinished"></translation>
+        <translation>Tachado</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6144"/>
         <source>Kerning</source>
-        <translation type="unfinished"></translation>
+        <translation>Interletraje</translation>
     </message>
 </context>
 <context>
@@ -379,7 +379,7 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="328"/>
         <source>Clear Shortcut</source>
-        <translation type="unfinished"></translation>
+        <translation>Borrar atajo</translation>
     </message>
 </context>
 <context>
@@ -387,17 +387,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2611"/>
         <source>%1, %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1, %2</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2664"/>
         <source>Language</source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2672"/>
         <source>Country</source>
-        <translation type="unfinished"></translation>
+        <translation>País</translation>
     </message>
 </context>
 <context>
@@ -405,17 +405,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3081"/>
         <source>(%1, %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>(%1, %2)</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3152"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation>X</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3160"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
 </context>
 <context>
@@ -423,17 +423,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2841"/>
         <source>(%1, %2)</source>
-        <translation type="unfinished"></translation>
+        <translation>(%1, %2)</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2878"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation>X</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2885"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
 </context>
 <context>
@@ -441,12 +441,12 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="187"/>
         <source>[%1, %2, %3] (%4)</source>
-        <translation type="unfinished"></translation>
+        <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="214"/>
         <source>[%1, %2]</source>
-        <translation type="unfinished"></translation>
+        <translation>[%1, %2]</translation>
     </message>
 </context>
 <context>
@@ -454,27 +454,27 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4586"/>
         <source>[(%1, %2), %3 x %4]</source>
-        <translation type="unfinished"></translation>
+        <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4742"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation>X</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4750"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4758"/>
         <source>Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Anchura</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4767"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Altura</translation>
     </message>
 </context>
 <context>
@@ -482,27 +482,27 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4156"/>
         <source>[(%1, %2), %3 x %4]</source>
-        <translation type="unfinished"></translation>
+        <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4276"/>
         <source>X</source>
-        <translation type="unfinished"></translation>
+        <translation>X</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4283"/>
         <source>Y</source>
-        <translation type="unfinished"></translation>
+        <translation>Y</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4290"/>
         <source>Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Anchura</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4298"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Altura</translation>
     </message>
 </context>
 <context>
@@ -510,17 +510,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3764"/>
         <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 x %2</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3894"/>
         <source>Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Anchura</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3903"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Altura</translation>
     </message>
 </context>
 <context>
@@ -529,32 +529,32 @@ Line %2, column %3</source>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5607"/>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5608"/>
         <source>&lt;Invalid&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;No válido&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5609"/>
         <source>[%1, %2, %3, %4]</source>
-        <translation type="unfinished"></translation>
+        <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5654"/>
         <source>Horizontal Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Política horizontal</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5663"/>
         <source>Vertical Policy</source>
-        <translation type="unfinished"></translation>
+        <translation>Política vertical</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5672"/>
         <source>Horizontal Stretch</source>
-        <translation type="unfinished"></translation>
+        <translation>Estiramiento horizontal</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5680"/>
         <source>Vertical Stretch</source>
-        <translation type="unfinished"></translation>
+        <translation>Estiramiento vertical</translation>
     </message>
 </context>
 <context>
@@ -562,17 +562,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3400"/>
         <source>%1 x %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 x %2</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3496"/>
         <source>Width</source>
-        <translation type="unfinished"></translation>
+        <translation>Anchura</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3504"/>
         <source>Height</source>
-        <translation type="unfinished"></translation>
+        <translation>Altura</translation>
     </message>
 </context>
 <context>
@@ -580,12 +580,12 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="478"/>
         <source>Property</source>
-        <translation type="unfinished"></translation>
+        <translation>Propiedad</translation>
     </message>
     <message>
         <location filename="../src/gui/contrib/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="479"/>
         <source>Value</source>
-        <translation type="unfinished"></translation>
+        <translation>Valor</translation>
     </message>
 </context>
 <context>
@@ -593,57 +593,57 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="33"/>
         <source>About %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Acerca de %1</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="82"/>
         <source>MapMap is a free/open source video mapping software.</source>
-        <translation type="unfinished"></translation>
+        <translation>MapMap es un software libre y de código abierto de mapeo de vídeo (video mapping).</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="84"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
-        <translation type="unfinished"></translation>
+        <translation>Derechos de autor &amp;copy; 2013 %1.</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="94"/>
         <source>See the </source>
-        <translation type="unfinished"></translation>
+        <translation>Consulte el </translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>%1 website</source>
-        <translation type="unfinished"></translation>
+        <translation>sitio web de %1</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>Acerca de</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="119"/>
         <source>Changelog</source>
-        <translation type="unfinished"></translation>
+        <translation>Registro de cambios</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="137"/>
         <source>Libraries</source>
-        <translation type="unfinished"></translation>
+        <translation>Bibliotecas</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="149"/>
         <source>Contributors</source>
-        <translation type="unfinished"></translation>
+        <translation>Colaboradores</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="161"/>
         <source>License</source>
-        <translation type="unfinished"></translation>
+        <translation>Licencia</translation>
     </message>
     <message>
         <location filename="../src/gui/AboutDialog.cpp" line="173"/>
         <source>OSC</source>
-        <translation type="unfinished"></translation>
+        <translation>OSC</translation>
     </message>
 </context>
 <context>
@@ -651,27 +651,27 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/ConsoleWindow.cpp" line="53"/>
         <source>Message Log Output - Mapmap</source>
-        <translation type="unfinished"></translation>
+        <translation>Registro de mensajes - Mapmap</translation>
     </message>
     <message>
         <location filename="../src/gui/ConsoleWindow.cpp" line="71"/>
         <source>&amp;Close</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Cerrar</translation>
     </message>
     <message>
         <location filename="../src/gui/ConsoleWindow.cpp" line="73"/>
         <source>Close the console</source>
-        <translation type="unfinished"></translation>
+        <translation>Cerrar la consola</translation>
     </message>
     <message>
         <location filename="../src/gui/ConsoleWindow.cpp" line="80"/>
         <source>&amp;File</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Archivo</translation>
     </message>
     <message>
         <location filename="../src/gui/ConsoleWindow.cpp" line="101"/>
         <source>MMM dd yy HH:mm</source>
-        <translation type="unfinished"></translation>
+        <translation>MMM dd yy HH:mm</translation>
     </message>
 </context>
 <context>
@@ -679,17 +679,17 @@ Line %2, column %3</source>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="122"/>
         <source>Image file</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo de imagen</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="124"/>
         <source>Image files (%1);;All files (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos de imagen (%1);;Todos los archivos (*)</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="128"/>
         <source>Speed (%)</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad (%)</translation>
     </message>
 </context>
 <context>
@@ -698,7 +698,7 @@ Line %2, column %3</source>
         <location filename="../src/gui/MainWindow.cpp" line="525"/>
         <location filename="../src/gui/MainWindow.cpp" line="531"/>
         <source>Open project</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="527"/>
@@ -706,691 +706,691 @@ Line %2, column %3</source>
         <location filename="../src/gui/MainWindow.cpp" line="565"/>
         <location filename="../src/gui/MainWindow.cpp" line="571"/>
         <source>MapMap files (*.%1)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos de MapMap (*.%1)</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="564"/>
         <location filename="../src/gui/MainWindow.cpp" line="570"/>
         <source>Save project</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="601"/>
         <location filename="../src/gui/MainWindow.cpp" line="609"/>
         <source>Import media source file</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar archivo de fuente multimedia</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="603"/>
         <location filename="../src/gui/MainWindow.cpp" line="611"/>
         <source>Media files (%1 %2);;All files (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos multimedia (%1 %2);;Todos los archivos (*)</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="646"/>
         <source>Camera device</source>
-        <translation type="unfinished"></translation>
+        <translation>Dispositivo de cámara</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="647"/>
         <source>Select camera</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar cámara</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="658"/>
         <location filename="../src/gui/MainWindow.cpp" line="669"/>
         <source>No camera available</source>
-        <translation type="unfinished"></translation>
+        <translation>No hay cámara disponible</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="658"/>
         <location filename="../src/gui/MainWindow.cpp" line="669"/>
         <source>You can not use this feature!
 No camera available in your system</source>
-        <translation type="unfinished"></translation>
+        <translation>No hay cámara disponible</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="684"/>
         <location filename="../src/gui/MainWindow.cpp" line="688"/>
         <source>Select Color</source>
-        <translation type="unfinished"></translation>
+        <translation>Seleccionar color</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1449"/>
         <location filename="../src/gui/MainWindow.cpp" line="1605"/>
         <location filename="../src/gui/MainWindow.cpp" line="2453"/>
         <source>MapMap</source>
-        <translation type="unfinished"></translation>
+        <translation>MapMap</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1619"/>
         <source>&amp;New</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Nuevo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1622"/>
         <source>Create a new project</source>
-        <translation type="unfinished"></translation>
+        <translation>Crear un nuevo proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1629"/>
         <source>&amp;Open...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Abrir...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1632"/>
         <source>Open an existing project</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir un proyecto existente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1639"/>
         <source>&amp;Save</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Guardar</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1642"/>
         <source>Save the project</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar el proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1649"/>
         <source>Save &amp;As...</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar &amp;como...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1652"/>
         <source>Save the project as...</source>
-        <translation type="unfinished"></translation>
+        <translation>Guardar el proyecto como...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1681"/>
         <source>No Recents Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>No hay vídeos recientes</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1686"/>
         <source>&amp;Import Media File...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Importar archivo multimedia...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1689"/>
         <source>Import a video or image file...</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar un archivo de vídeo o imagen...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1697"/>
         <source>Open &amp;Camera Device...</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir dispositivo de &amp;cámara...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1701"/>
         <source>Choose your camera device...</source>
-        <translation type="unfinished"></translation>
+        <translation>Elija su dispositivo de cámara...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1711"/>
         <source>Add a color paint...</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir una pintura de color...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1718"/>
         <source>E&amp;xit</source>
-        <translation type="unfinished"></translation>
+        <translation>S&amp;alir</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1720"/>
         <source>Exit the application</source>
-        <translation type="unfinished"></translation>
+        <translation>Salir de la aplicación</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1727"/>
         <source>&amp;Undo</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Deshacer</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1734"/>
         <source>&amp;Redo</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Rehacer</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1741"/>
         <source>&amp;About MapMap</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Acerca de MapMap</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1742"/>
         <source>Show the application&apos;s About box</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar el cuadro Acerca de de la aplicación</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1855"/>
         <source>&amp;Preferences...</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Preferencias...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1858"/>
         <source>Configure preferences...</source>
-        <translation type="unfinished"></translation>
+        <translation>Configurar preferencias...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1899"/>
         <location filename="../src/gui/MainWindow.cpp" line="1902"/>
         <source>Play</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1910"/>
         <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>Pause</source>
-        <translation type="unfinished"></translation>
+        <translation>Pausa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1931"/>
         <source>Toggle &amp;Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Alternar &amp;pantalla completa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1934"/>
         <source>Toggle Fullscreen</source>
-        <translation type="unfinished"></translation>
+        <translation>Alternar pantalla completa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1952"/>
         <source>&amp;Display Controls</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Mostrar controles</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Display canvas controls</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar los controles del lienzo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1981"/>
         <source>&amp;Sticky Vertices</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Vértices magnéticos</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1984"/>
         <source>Enable sticky vertices</source>
-        <translation type="unfinished"></translation>
+        <translation>Activar vértices magnéticos</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1993"/>
         <source>Show &amp;Test Signal</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar señal de &amp;prueba</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1996"/>
         <source>Show Test signal</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar señal de prueba</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2007"/>
         <source>Display &amp;Undo History</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar &amp;historial de deshacer</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2017"/>
         <source>Open Conso&amp;le</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir conso&amp;la</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2028"/>
         <source>Display &amp;Zoom Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar barra de &amp;zoom</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2038"/>
         <source>&amp;Menu Bar</source>
-        <translation type="unfinished"></translation>
+        <translation>Barra de &amp;menús</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2045"/>
         <source>Main Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Disposición principal</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2049"/>
         <source>Switch to the Main layout.</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambiar a la disposición principal.</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1450"/>
         <source>Remove this source and all its associated layers?</source>
-        <translation type="unfinished"></translation>
+        <translation>¿Quitar esta fuente y todas sus capas asociadas?</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1521"/>
         <source>Input Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Editor de entrada</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1537"/>
         <source>Output Editor</source>
-        <translation type="unfinished"></translation>
+        <translation>Editor de salida</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1583"/>
         <source>Library</source>
-        <translation type="unfinished"></translation>
+        <translation>Biblioteca</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1584"/>
         <source>Layers</source>
-        <translation type="unfinished"></translation>
+        <translation>Capas</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1708"/>
         <source>Add &amp;Color Source...</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir fuente de &amp;color...</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1749"/>
         <source>Duplicate Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1751"/>
         <source>Duplicate layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar elemento de capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Delete Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1761"/>
         <source>Delete layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar elemento de capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1769"/>
         <source>Rename Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Renombrar capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1771"/>
         <source>Rename layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>Renombrar elemento de capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1779"/>
         <source>Lock Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Bloquear capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1780"/>
         <source>Lock layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>Bloquear elemento de capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1790"/>
         <source>Hide Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocultar capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1791"/>
         <source>Hide layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>Ocultar elemento de capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1801"/>
         <source>Solo Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Capa en solo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1802"/>
         <source>solo layer item</source>
-        <translation type="unfinished"></translation>
+        <translation>elemento de capa en solo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1812"/>
         <location filename="../src/gui/MainWindow.cpp" line="1813"/>
         <source>Flip Horizontally</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltear horizontalmente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1820"/>
         <location filename="../src/gui/MainWindow.cpp" line="1821"/>
         <source>Flip Vertically</source>
-        <translation type="unfinished"></translation>
+        <translation>Voltear verticalmente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Delete Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1830"/>
         <source>Delete source item</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar elemento de fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1838"/>
         <source>Rename Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Renombrar fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1840"/>
         <source>Rename source item</source>
-        <translation type="unfinished"></translation>
+        <translation>Renombrar elemento de fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1848"/>
         <source>Import New Media</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar nuevo archivo multimedia</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1849"/>
         <source>Import new media file if not exists on the list</source>
-        <translation type="unfinished"></translation>
+        <translation>Importar un nuevo archivo multimedia si no está en la lista</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Add &amp;Mesh Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de &amp;malla</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1868"/>
         <source>Add mesh layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de malla</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Add &amp;Triangle Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de &amp;triángulo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1879"/>
         <source>Add triangle layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de triángulo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1887"/>
         <source>Add &amp;Ellipse Layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de &amp;elipse</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1890"/>
         <source>Add ellipse layer</source>
-        <translation type="unfinished"></translation>
+        <translation>Añadir capa de elipse</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1921"/>
         <location filename="../src/gui/MainWindow.cpp" line="1924"/>
         <source>Restart</source>
-        <translation type="unfinished"></translation>
+        <translation>Reiniciar</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>&amp;Display Controls of Layers of a Source</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Mostrar controles de las capas de una fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1969"/>
         <source>Display all canvas controls related to current source</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar todos los controles del lienzo relacionados con la fuente actual</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2053"/>
         <source>Input editor Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Disposición del editor de entrada</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2056"/>
         <source>Switch to the Input editor Layout.</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambiar a la disposición del editor de entrada.</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2060"/>
         <source>Output Editor Layout</source>
-        <translation type="unfinished"></translation>
+        <translation>Disposición del editor de salida</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2063"/>
         <source>Switch to the Output Editors Layout.</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambiar a la disposición del editor de salida.</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2074"/>
         <location filename="../src/gui/MainWindow.cpp" line="2076"/>
         <source>Zoom In</source>
-        <translation type="unfinished"></translation>
+        <translation>Acercar</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2081"/>
         <location filename="../src/gui/MainWindow.cpp" line="2083"/>
         <source>Zoom Out</source>
-        <translation type="unfinished"></translation>
+        <translation>Alejar</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2088"/>
         <source>Original Size</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamaño original</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2090"/>
         <source>Reset zoom to original size</source>
-        <translation type="unfinished"></translation>
+        <translation>Restablecer el zoom al tamaño original</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2095"/>
         <source>Fit To View</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustar a la vista</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2096"/>
         <source>Fit to viewport</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustar a la ventana gráfica</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2103"/>
         <source>Report an issue</source>
-        <translation type="unfinished"></translation>
+        <translation>Informar de un problema</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2106"/>
         <source>Technical support</source>
-        <translation type="unfinished"></translation>
+        <translation>Soporte técnico</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2109"/>
         <source>Documentation</source>
-        <translation type="unfinished"></translation>
+        <translation>Documentación</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2112"/>
         <source>Submit feedback via email</source>
-        <translation type="unfinished"></translation>
+        <translation>Enviar comentarios por correo electrónico</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2140"/>
         <source>&amp;File</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Archivo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2154"/>
         <source>Open Recents Projects</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir proyectos recientes</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2161"/>
         <source>Open Recents Videos</source>
-        <translation type="unfinished"></translation>
+        <translation>Abrir vídeos recientes</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2172"/>
         <source>&amp;Edit</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Editar</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2196"/>
         <source>&amp;View</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;Ver</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2207"/>
         <source>&amp;Output screen</source>
-        <translation type="unfinished"></translation>
+        <translation>Pantalla de &amp;salida</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2216"/>
         <source>&amp;Window</source>
-        <translation type="unfinished"></translation>
+        <translation>Ve&amp;ntana</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2240"/>
         <source>&amp;Help</source>
-        <translation type="unfinished"></translation>
+        <translation>A&amp;yuda</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2268"/>
         <source>Change Layer Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Cambiar la fuente de la capa</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>&amp;Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>Barra de &amp;herramientas</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2454"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
-        <translation type="unfinished"></translation>
+        <translation>Barra de &amp;herramientas</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2476"/>
         <location filename="../src/gui/MainWindow.cpp" line="2490"/>
         <source>Error reading mapping project file</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2477"/>
         <location filename="../src/gui/MainWindow.cpp" line="2727"/>
         <source>Cannot read file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2491"/>
         <source>Parse error in file %1:
 
 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al leer el archivo de proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>File loaded</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo cargado</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2510"/>
         <source>Error saving mapping project</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al guardar el proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2511"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation type="unfinished"></translation>
+        <translation>Error al guardar el proyecto</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2521"/>
         <source>File saved</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo guardado</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2533"/>
         <source>Untitled</source>
-        <translation type="unfinished"></translation>
+        <translation>Sin título</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2548"/>
         <source>%1[*] - %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1[*] - %2</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2548"/>
         <location filename="../src/gui/MainWindow.cpp" line="2726"/>
         <source>MapMap Project</source>
-        <translation type="unfinished"></translation>
+        <translation>Proyecto de MapMap</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2571"/>
         <location filename="../src/gui/MainWindow.cpp" line="2603"/>
         <location filename="../src/gui/MainWindow.cpp" line="2657"/>
         <source>&amp;%1 %2</source>
-        <translation type="unfinished"></translation>
+        <translation>&amp;%1 %2</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2588"/>
         <source>Clear List</source>
-        <translation type="unfinished"></translation>
+        <translation>Vaciar lista</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2591"/>
         <source>No Recents Projects</source>
-        <translation type="unfinished"></translation>
+        <translation>No hay proyectos recientes</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2624"/>
         <source>%1 - %2x%3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 - %2x%3</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2629"/>
         <source> - Primary</source>
-        <translation type="unfinished"></translation>
+        <translation> - Principal</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2758"/>
         <source>File imported</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivo importado</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2779"/>
         <source>Color source added</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuente de color añadida</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>Advertencia</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3095"/>
         <source>The following file is not supported: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>El siguiente archivo no es compatible: %1</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3122"/>
         <source>Cannot load movie</source>
-        <translation type="unfinished"></translation>
+        <translation>No se puede cargar el vídeo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3123"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
-        <translation type="unfinished"></translation>
+        <translation>No se puede cargar el vídeo</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3130"/>
         <location filename="../src/gui/MainWindow.cpp" line="3138"/>
         <source>Locate file %1</source>
-        <translation type="unfinished"></translation>
+        <translation>Localizar el archivo %1</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3132"/>
         <location filename="../src/gui/MainWindow.cpp" line="3140"/>
         <source>%1 files (%2)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos %1 (%2)</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="3265"/>
         <source>Undo history</source>
-        <translation type="unfinished"></translation>
+        <translation>Historial de deshacer</translation>
     </message>
 </context>
 <context>
@@ -1398,22 +1398,22 @@ The original file is not found. Please locate.</source>
     <message>
         <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="54"/>
         <source>Enlarge the shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Agrandar la forma</translation>
     </message>
     <message>
         <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="62"/>
         <source>Shrink the shape</source>
-        <translation type="unfinished"></translation>
+        <translation>Encoger la forma</translation>
     </message>
     <message>
         <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="70"/>
         <source>Reset the shape to the normal size</source>
-        <translation type="unfinished"></translation>
+        <translation>Restablecer la forma a su tamaño normal</translation>
     </message>
     <message>
         <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="78"/>
         <source>Fit the shape to content view</source>
-        <translation type="unfinished"></translation>
+        <translation>Ajustar la forma a la vista</translation>
     </message>
 </context>
 <context>
@@ -1421,22 +1421,22 @@ The original file is not found. Please locate.</source>
     <message>
         <location filename="../src/gui/MappingItemDelegate.cpp" line="99"/>
         <source>Solo mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Mapeo en solo</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingItemDelegate.cpp" line="111"/>
         <source>Lock mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Bloquear mapeo</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingItemDelegate.cpp" line="123"/>
         <source>Duplicate mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Duplicar mapeo</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingItemDelegate.cpp" line="135"/>
         <source>Delete mapping</source>
-        <translation type="unfinished"></translation>
+        <translation>Eliminar mapeo</translation>
     </message>
 </context>
 <context>
@@ -1444,12 +1444,12 @@ The original file is not found. Please locate.</source>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="427"/>
         <source>Horizontal</source>
-        <translation type="unfinished"></translation>
+        <translation>Horizontal</translation>
     </message>
     <message>
         <location filename="../src/gui/MappingGui.cpp" line="428"/>
         <source>Vertical</source>
-        <translation type="unfinished"></translation>
+        <translation>Vertical</translation>
     </message>
 </context>
 <context>
@@ -1457,147 +1457,147 @@ The original file is not found. Please locate.</source>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="59"/>
         <source>Preferences</source>
-        <translation type="unfinished"></translation>
+        <translation>Preferencias</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="182"/>
         <source>Large</source>
-        <translation type="unfinished"></translation>
+        <translation>Grande</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="183"/>
         <source>Medium</source>
-        <translation type="unfinished"></translation>
+        <translation>Mediano</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="184"/>
         <source>Small</source>
-        <translation type="unfinished"></translation>
+        <translation>Pequeño</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="188"/>
         <source>Language (requires restart)</source>
-        <translation type="unfinished"></translation>
+        <translation>Idioma (requiere reiniciar)</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="192"/>
         <source>Toolbar icon size (requires restart)</source>
-        <translation type="unfinished"></translation>
+        <translation>Tamaño de los iconos de la barra de herramientas (requiere reiniciar)</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Enable Sticky vertices</source>
-        <translation type="unfinished"></translation>
+        <translation>Activar vértices magnéticos</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="220"/>
         <source>Sensitivity</source>
-        <translation type="unfinished"></translation>
+        <translation>Sensibilidad</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="222"/>
         <source>Vertices</source>
-        <translation type="unfinished"></translation>
+        <translation>Vértices</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="248"/>
         <source>Only show output controls on mouse over</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar los controles de salida solo al pasar el ratón</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="253"/>
         <source>Output Layers</source>
-        <translation type="unfinished"></translation>
+        <translation>Capas de salida</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="257"/>
         <source>Show resolution on output test cards</source>
-        <translation type="unfinished"></translation>
+        <translation>Mostrar la resolución en las cartas de ajuste de salida</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="259"/>
         <source>Classic test card</source>
-        <translation type="unfinished"></translation>
+        <translation>Carta de ajuste clásica</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="260"/>
         <source>PAL test card</source>
-        <translation type="unfinished"></translation>
+        <translation>Carta de ajuste PAL</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="261"/>
         <source>NTSC test card</source>
-        <translation type="unfinished"></translation>
+        <translation>Carta de ajuste NTSC</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="290"/>
         <source>Test Card</source>
-        <translation type="unfinished"></translation>
+        <translation>Carta de ajuste</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="337"/>
         <source>Listen to OSC messages</source>
-        <translation type="unfinished"></translation>
+        <translation>Escuchar mensajes OSC</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="344"/>
         <source>Allow message with existing media source</source>
-        <translation type="unfinished"></translation>
+        <translation>Permitir mensaje con fuente multimedia existente</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="349"/>
         <source>on port</source>
-        <translation type="unfinished"></translation>
+        <translation>en el puerto</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="352"/>
         <source>Refresh</source>
-        <translation type="unfinished"></translation>
+        <translation>Actualizar</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="362"/>
         <source>Local IP</source>
-        <translation type="unfinished"></translation>
+        <translation>IP local</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="374"/>
         <source>OSC Setup</source>
-        <translation type="unfinished"></translation>
+        <translation>Configuración de OSC</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="387"/>
         <source>Play in loop (requires restart)</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducir en bucle (requiere reiniciar)</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="395"/>
         <source>Playback</source>
-        <translation type="unfinished"></translation>
+        <translation>Reproducción</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="401"/>
         <source>Interface</source>
-        <translation type="unfinished"></translation>
+        <translation>Interfaz</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="404"/>
         <source>Layers</source>
-        <translation type="unfinished"></translation>
+        <translation>Capas</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="407"/>
         <source>Output</source>
-        <translation type="unfinished"></translation>
+        <translation>Salida</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="410"/>
         <source>Controls</source>
-        <translation type="unfinished"></translation>
+        <translation>Controles</translation>
     </message>
     <message>
         <location filename="../src/gui/PreferenceDialog.cpp" line="413"/>
         <source>Advanced</source>
-        <translation type="unfinished"></translation>
+        <translation>Avanzado</translation>
     </message>
 </context>
 <context>
@@ -1605,22 +1605,22 @@ The original file is not found. Please locate.</source>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="170"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation>Fuente</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="172"/>
         <source>Video files (%1);;All files (*)</source>
-        <translation type="unfinished"></translation>
+        <translation>Archivos de vídeo (%1);;Todos los archivos (*)</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="176"/>
         <source>Speed (%)</source>
-        <translation type="unfinished"></translation>
+        <translation>Velocidad (%)</translation>
     </message>
     <message>
         <location filename="../src/gui/PaintGui.cpp" line="183"/>
         <source>Volume (%)</source>
-        <translation type="unfinished"></translation>
+        <translation>Volumen (%)</translation>
     </message>
 </context>
 </TS>

--- a/translations/mapmap_fr.ts
+++ b/translations/mapmap_fr.ts
@@ -27,6 +27,8 @@
 <context>
     <name>FileEdit</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="55"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="57"/>
         <source>Choose a file</source>
         <translation>Choisir un fichier</translation>
     </message>
@@ -474,14 +476,17 @@ No camera available in your system</source>
         <translation type="vanished">Mapping texturé</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="289"/>
         <source>Input shape</source>
         <translation>Forme en entrée</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="63"/>
         <source>Output shape</source>
         <translation>Forme en sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="151"/>
         <source>Point %1</source>
         <translation>Point %1</translation>
     </message>
@@ -492,7 +497,7 @@ No camera available in your system</source>
     <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1
+        <translation type="vanished">%1
 Ligne %2, colonne %3</translation>
     </message>
     <message>
@@ -544,10 +549,12 @@ Ligne %2, colonne %3</translation>
         <translation type="vanished">Mauvais type de forme &quot;%1&quot; pour la destination. On s&apos;attend à &quot;%2&quot;</translation>
     </message>
     <message>
+        <location filename="../src/app/main.cpp" line="183"/>
         <source>Initiating program...</source>
         <translation>Lancement du logiciel...</translation>
     </message>
     <message>
+        <location filename="../src/app/main.cpp" line="244"/>
         <source>Done.</source>
         <translation>Terminé.</translation>
     </message>
@@ -564,10 +571,12 @@ Ligne %2, colonne %3</translation>
         <translation type="vanished">Dupliquer un mapping</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="148"/>
         <source>Move vertex</source>
         <translation>Déplacer le sommet</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="235"/>
         <source>Move shape</source>
         <translation>Déplacer la forme</translation>
     </message>
@@ -580,18 +589,26 @@ Ligne %2, colonne %3</translation>
         <translation type="vanished">Supprimer le mapping</translation>
     </message>
     <message>
+        <location filename="../src/core/Layer.cpp" line="148"/>
         <source>Problem at creation of shape.</source>
         <translation>Problème à la création de la forme.</translation>
     </message>
     <message>
+        <location filename="../src/core/Layer.cpp" line="160"/>
+        <source>Unable to create shape of type &apos;%1&apos;.</source>
+        <translation>Impossible de créer une forme de type « %1 ».</translation>
+    </message>
+    <message>
         <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation>Impossible de créer une source de type &apos;%1&apos;.</translation>
+        <translation type="vanished">Impossible de créer une source de type &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>Mapping</source>
         <translation type="vanished">Mapping</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="50"/>
+        <location filename="../src/gui/SourceGui.cpp" line="48"/>
         <source>Opacity (%)</source>
         <translation>Opacité (%)</translation>
     </message>
@@ -600,6 +617,7 @@ Ligne %2, colonne %3</translation>
         <translation type="vanished">Source</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="92"/>
         <source>Color</source>
         <translation>Couleur</translation>
     </message>
@@ -609,80 +627,137 @@ Ligne %2, colonne %3</translation>
     </message>
     <message>
         <source>Problem at creation of paint.</source>
-        <translation>Problème à la création de la peinture.</translation>
-    </message>
-    <message>
-        <source></source>
-        <translation></translation>
+        <translation type="vanished">Problème à la création de la peinture.</translation>
     </message>
     <message>
         <source>Problem at creation of mapping.</source>
-        <translation>Problème à la création du mapping.</translation>
+        <translation type="vanished">Problème à la création du mapping.</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="44"/>
+        <location filename="../src/gui/SourceGui.cpp" line="42"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="36"/>
         <source>Add source</source>
         <translation>Ajouter une source</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="62"/>
         <source>Add layer</source>
         <translation>Ajouter une couche</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="87"/>
         <source>Duplicate layer</source>
         <translation>Dupliquer la couche</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="265"/>
         <source>Remove media</source>
         <translation>Retirer le média</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="307"/>
         <source>Delete layer</source>
         <translation>Supprimer la couche</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="333"/>
+        <source>Raise layer</source>
+        <translation>Monter la couche</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="334"/>
+        <source>Lower layer</source>
+        <translation>Descendre la couche</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="335"/>
+        <source>Raise layer to top</source>
+        <translation>Monter la couche tout en haut</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="336"/>
+        <source>Lower layer to bottom</source>
+        <translation>Descendre la couche tout en bas</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="380"/>
+        <source>Flip Horizontally</source>
+        <translation>Retourner horizontalement</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="385"/>
+        <source>Flip Vertically</source>
+        <translation>Retourner verticalement</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="424"/>
+        <source>Rotate 90° CW</source>
+        <translation>Pivoter de 90° dans le sens horaire</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="429"/>
+        <source>Rotate 90° CCW</source>
+        <translation>Pivoter de 90° dans le sens antihoraire</translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="434"/>
+        <source>Rotate 180°</source>
+        <translation>Pivoter de 180°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerGui.cpp" line="195"/>
         <source>Mesh Subdivisions</source>
         <translation>Subdivisions de maillage</translation>
     </message>
     <message>
+        <location filename="../src/gui/LayerGui.cpp" line="424"/>
         <source>Subdivisions</source>
         <translation>Subdivisions</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Rotate shape</source>
         <translation>Tourner la forme</translation>
     </message>
     <message>
+        <location filename="../src/core/Commands.cpp" line="198"/>
         <source>Scale shape</source>
         <translation>Mettre à l&apos;échelle la forme</translation>
     </message>
     <message>
+        <location filename="../src/core/ProjectReader.cpp" line="50"/>
         <source>The contents of this file does not look like a MapMap project.</source>
         <translation>Le contenu de ce fichier ne ressemble pas à un projet MapMap.</translation>
     </message>
     <message>
+        <location filename="../src/core/ProjectReader.cpp" line="53"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
         <translation>La version de MapMap (%1) utilisée pour sauvegarder ce fichier n&apos;est pas lisible par cette version de MapMap (%2).</translation>
     </message>
     <message>
-        <source>Flipped Horizontally</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Flipped Vertically</source>
-        <translation type="unfinished"></translation>
+        <location filename="../src/core/ProjectReader.cpp" line="178"/>
+        <location filename="../src/core/ProjectReader.cpp" line="187"/>
+        <source>Unable to create layer of type &apos;%1&apos;.</source>
+        <translation>Impossible de créer une couche de type « %1 ».</translation>
     </message>
 </context>
 <context>
     <name>QtBoolEdit</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="233"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>True</source>
         <translation>vrai</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="243"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="268"/>
         <source>False</source>
         <translation>faux</translation>
     </message>
@@ -690,10 +765,12 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtBoolPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="1696"/>
         <source>True</source>
         <translation>vrai</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="1697"/>
         <source>False</source>
         <translation>faux</translation>
     </message>
@@ -701,6 +778,7 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtCharEdit</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="1700"/>
         <source>Clear Char</source>
         <translation>Effacer le charactère</translation>
     </message>
@@ -708,6 +786,7 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtColorEditWidget</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2314"/>
         <source>...</source>
         <translation>...</translation>
     </message>
@@ -715,18 +794,22 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtColorPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6421"/>
         <source>Red</source>
         <translation>Rouge</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6429"/>
         <source>Green</source>
         <translation>Vert</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6437"/>
         <source>Blue</source>
         <translation>Bleu</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6445"/>
         <source>Alpha</source>
         <translation>Transparence</translation>
     </message>
@@ -734,78 +817,97 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtCursorDatabase</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="58"/>
         <source>Arrow</source>
         <translation>Flèche</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="60"/>
         <source>Up Arrow</source>
         <translation>Flèche vers le haut</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="62"/>
         <source>Cross</source>
         <translation>Traverser</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="64"/>
         <source>Wait</source>
         <translation>Attendre</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="66"/>
         <source>IBeam</source>
         <translation>IBeam</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="68"/>
         <source>Size Vertical</source>
         <translation>Dimensionner Vertical</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="70"/>
         <source>Size Horizontal</source>
         <translation>Dimensionner Horizontal</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="72"/>
         <source>Size Backslash</source>
         <translation>Dimensionner Barre Oblique Inversée</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="74"/>
         <source>Size Slash</source>
         <translation>Dimensionner Barre Oblique</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="76"/>
         <source>Size All</source>
         <translation>Tout dimensionner</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="78"/>
         <source>Blank</source>
         <translation>Vide</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="80"/>
         <source>Split Vertical</source>
         <translation>Séparer verticalement</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="82"/>
         <source>Split Horizontal</source>
         <translation>Séparer horizontalement</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="84"/>
         <source>Pointing Hand</source>
         <translation>Main pointant</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="86"/>
         <source>Forbidden</source>
         <translation>Interdit</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="88"/>
         <source>Open Hand</source>
         <translation>Main ouverte</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="90"/>
         <source>Closed Hand</source>
         <translation>Main fermée</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="92"/>
         <source>What&apos;s This</source>
         <translation>Qu&apos;est-ce que c&apos;est</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="94"/>
         <source>Busy</source>
         <translation>Occupé</translation>
     </message>
@@ -813,10 +915,12 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtFontEditWidget</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2521"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2541"/>
         <source>Select Font</source>
         <translation>Sélectionner une police</translation>
     </message>
@@ -824,30 +928,37 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtFontPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6095"/>
         <source>Family</source>
         <translation>Famille</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6108"/>
         <source>Point Size</source>
         <translation>Taille du point</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6116"/>
         <source>Bold</source>
         <translation>Gras</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6123"/>
         <source>Italic</source>
         <translation>Italique</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6130"/>
         <source>Underline</source>
         <translation>Souligner</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6137"/>
         <source>Strikeout</source>
         <translation>Barrer</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="6144"/>
         <source>Kerning</source>
         <translation>Crénage</translation>
     </message>
@@ -855,6 +966,7 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtKeySequenceEdit</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="328"/>
         <source>Clear Shortcut</source>
         <translation>Effacer le raccourci</translation>
     </message>
@@ -862,14 +974,17 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtLocalePropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2611"/>
         <source>%1, %2</source>
         <translation>%1, %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2664"/>
         <source>Language</source>
         <translation>Langue</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2672"/>
         <source>Country</source>
         <translation>Pays</translation>
     </message>
@@ -877,14 +992,17 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtPointFPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3081"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3152"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3160"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -892,14 +1010,17 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtPointPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2841"/>
         <source>(%1, %2)</source>
         <translation>(%1, %2)</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2878"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="2885"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
@@ -907,10 +1028,12 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtPropertyBrowserUtils</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="187"/>
         <source>[%1, %2, %3] (%4)</source>
         <translation>[%1, %2, %3] (%4)</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertybrowserutils.cpp" line="214"/>
         <source>[%1, %2]</source>
         <translation>[%1, %2]</translation>
     </message>
@@ -918,22 +1041,27 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtRectFPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4586"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4742"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4750"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4758"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4767"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -941,22 +1069,27 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtRectPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4156"/>
         <source>[(%1, %2), %3 x %4]</source>
         <translation>[(%1, %2), %3 x %4]</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4276"/>
         <source>X</source>
         <translation>X</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4283"/>
         <source>Y</source>
         <translation>Y</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4290"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="4298"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -964,14 +1097,17 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtSizeFPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3764"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3894"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3903"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -979,26 +1115,33 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtSizePolicyPropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5607"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5608"/>
         <source>&lt;Invalid&gt;</source>
         <translation>&lt;Invalide&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5609"/>
         <source>[%1, %2, %3, %4]</source>
         <translation>[%1, %2, %3, %4]</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5654"/>
         <source>Horizontal Policy</source>
         <translation>Police horizontale</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5663"/>
         <source>Vertical Policy</source>
         <translation>Police verticale</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5672"/>
         <source>Horizontal Stretch</source>
         <translation>Étirement horizontal</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="5680"/>
         <source>Vertical Stretch</source>
         <translation>Étirement vertical</translation>
     </message>
@@ -1006,14 +1149,17 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtSizePropertyManager</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3400"/>
         <source>%1 x %2</source>
         <translation>%1 x %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3496"/>
         <source>Width</source>
         <translation>Largeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qtpropertymanager.cpp" line="3504"/>
         <source>Height</source>
         <translation>Hauteur</translation>
     </message>
@@ -1021,10 +1167,12 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>QtTreePropertyBrowser</name>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="478"/>
         <source>Property</source>
         <translation>Propriété</translation>
     </message>
     <message>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qttreepropertybrowser.cpp" line="479"/>
         <source>Value</source>
         <translation>Valeur</translation>
     </message>
@@ -1032,69 +1180,105 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>mmp::AboutDialog</name>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="33"/>
         <source>About %1</source>
         <translation>À propos de %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="93"/>
         <source>MapMap is a free/open source video mapping software.</source>
         <translation>MapMap est un logiciel libre de mapping vidéo.</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>See the </source>
         <translation>Voir le </translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="108"/>
         <source>%1 website</source>
         <translation>site web de %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="111"/>
+        <source>%1 is developed and sponsored by Art Plus Code. Need a custom video mapping installation, a new feature, integration or training? </source>
+        <translation>%1 est développé et commandité par Art Plus Code. Besoin d&apos;une installation de mapping vidéo sur mesure, d&apos;une nouvelle fonctionnalité, d&apos;intégration ou de formation ? </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="114"/>
+        <source>Hire us</source>
+        <translation>Engagez-nous</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="115"/>
+        <source>Enjoying %1? </source>
+        <translation>Vous aimez %1 ? </translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="116"/>
+        <source>Support the project</source>
+        <translation>Soutenir le projet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="132"/>
         <source>About</source>
         <translation>À propos</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="144"/>
         <source>Changelog</source>
         <translation>Changements</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="170"/>
         <source>Contributors</source>
         <translation>Contributeurs</translation>
     </message>
     <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="183"/>
         <source>License</source>
         <translation>Licence</translation>
     </message>
     <message>
-        <source>Libraries</source>
-        <translation>Librairies</translation>
+        <location filename="../src/gui/AboutDialog.cpp" line="196"/>
+        <source>OSC Commands</source>
+        <translation>Commandes OSC</translation>
     </message>
     <message>
-        <source>OSC</source>
-        <translation></translation>
+        <location filename="../src/gui/AboutDialog.cpp" line="159"/>
+        <source>Libraries</source>
+        <translation>Librairies</translation>
     </message>
 </context>
 <context>
     <name>mmp::ConsoleWindow</name>
     <message>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="53"/>
         <source>Message Log Output - Mapmap</source>
         <translation>Registre des message - MapMap</translation>
     </message>
     <message>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="71"/>
         <source>&amp;Close</source>
         <translation>&amp;Fermer</translation>
     </message>
     <message>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="73"/>
         <source>Close the console</source>
         <translation>Fermer la console</translation>
     </message>
     <message>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="80"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="104"/>
         <source>MMM dd yy HH:mm</source>
         <translation>dd MMM yy HH:mm</translation>
     </message>
@@ -1102,37 +1286,75 @@ Ligne %2, colonne %3</translation>
 <context>
     <name>mmp::ImageGui</name>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="126"/>
         <source>Image file</source>
         <translation>Fichier image</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="128"/>
         <source>Image files (%1);;All files (*)</source>
         <translation>Fichiers image (%1);;Tous les fichiers (*)</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="132"/>
         <source>Speed (%)</source>
         <translation>Vitesse (%)</translation>
     </message>
 </context>
 <context>
+    <name>mmp::LayerItemDelegate</name>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="100"/>
+        <source>Solo mapping</source>
+        <translation>Mapping en solo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="112"/>
+        <source>Lock mapping</source>
+        <translation>Verrouiller le mapping</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="124"/>
+        <source>Duplicate mapping</source>
+        <translation>Dupliquer le mapping</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="136"/>
+        <source>Delete mapping</source>
+        <translation>Supprimer le mapping</translation>
+    </message>
+</context>
+<context>
     <name>mmp::MainWindow</name>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="554"/>
         <source>Open project</source>
         <translation>Ouvrir un projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="550"/>
+        <location filename="../src/gui/MainWindow.cpp" line="556"/>
+        <location filename="../src/gui/MainWindow.cpp" line="588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="594"/>
         <source>MapMap files (*.%1)</source>
         <translation>Fichiers MapMap (*.%1)</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="587"/>
+        <location filename="../src/gui/MainWindow.cpp" line="593"/>
         <source>Save project</source>
         <translation>Sauvegarder le projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="632"/>
         <source>Import media source file</source>
         <translation>Importer un média</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="626"/>
+        <location filename="../src/gui/MainWindow.cpp" line="634"/>
         <source>Media files (%1 %2);;All files (*)</source>
         <translation>Fichiers média (%1-%2);;Tous les fichiers (*)</translation>
     </message>
@@ -1141,23 +1363,33 @@ Ligne %2, colonne %3</translation>
         <translation type="vanished">Caméras disponibles</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="673"/>
         <source>Select camera</source>
         <translation>Selectionner une caméra</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>No camera available</source>
         <translation>Aucune caméra disponible</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>You can not use this feature!
 No camera available in your system</source>
         <translation>Vous ne pouvez pas utiliser cette fonctionnalité. Aucune caméra disponible sur ce système</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="717"/>
+        <location filename="../src/gui/MainWindow.cpp" line="721"/>
         <source>Select Color</source>
         <translation>Choisir une couleur</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1620"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1781"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2769"/>
         <source>MapMap</source>
         <translation>MapMap</translation>
     </message>
@@ -1182,54 +1414,67 @@ No camera available in your system</source>
         <translation type="vanished">Mappings</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1795"/>
         <source>&amp;New</source>
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1798"/>
         <source>Create a new project</source>
         <translation>Créer un nouveau projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1805"/>
         <source>&amp;Open...</source>
         <translation>&amp;Ouvrir...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1808"/>
         <source>Open an existing project</source>
         <translation>Ouvrir un projet existant</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1815"/>
         <source>&amp;Save</source>
         <translation>&amp;Sauvegarder</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1818"/>
         <source>Save the project</source>
         <translation>Sauvegarder le projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1825"/>
         <source>Save &amp;As...</source>
         <translation>S&amp;auvegarder sous...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Save the project as...</source>
         <translation>Sauvegarder le projet sous...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1857"/>
         <source>No Recents Videos</source>
         <translation>Pas de vidéos récentes</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1862"/>
         <source>&amp;Import Media File...</source>
         <translation>&amp;Importer un fichier média ...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Import a video or image file...</source>
         <translation>Importer un fichier vidéo ou image ...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1872"/>
         <source>Open &amp;Camera Device...</source>
         <translation>Ajouter une source &amp;caméra...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Choose your camera device...</source>
         <translation>Choisir la caméra...</translation>
     </message>
@@ -1239,29 +1484,35 @@ No camera available in your system</source>
     </message>
     <message>
         <source>Add a color paint...</source>
-        <translation>Ajouter une source couleur...</translation>
+        <translation type="vanished">Ajouter une source couleur...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1904"/>
         <source>E&amp;xit</source>
         <translation>&amp;Quitter</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1906"/>
         <source>Exit the application</source>
         <translation>Quitter l&apos;application</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>&amp;Undo</source>
         <translation>Ann&amp;uler</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1920"/>
         <source>&amp;Redo</source>
         <translation>&amp;Retablir</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1927"/>
         <source>&amp;About MapMap</source>
         <translation>&amp;A propos de MapMap</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1928"/>
         <source>Show the application&apos;s About box</source>
         <translation>Afficher le dialogue &quot;À propos de l&apos;application&quot;</translation>
     </message>
@@ -1318,10 +1569,12 @@ No camera available in your system</source>
         <translation type="vanished">Supprimer la source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2099"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;Préférences...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2102"/>
         <source>Configure preferences...</source>
         <translation>Configurer les préférences...</translation>
     </message>
@@ -1350,10 +1603,14 @@ No camera available in your system</source>
         <translation type="vanished">Ajouter une ellipse</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2143"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2146"/>
         <source>Play</source>
         <translation>Lecture</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2157"/>
         <source>Pause</source>
         <translation>Pause</translation>
     </message>
@@ -1362,18 +1619,22 @@ No camera available in your system</source>
         <translation type="vanished">Rembobiner</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2175"/>
         <source>Toggle &amp;Fullscreen</source>
         <translation>&amp;Plein écran</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2178"/>
         <source>Toggle Fullscreen</source>
         <translation>Plein écran</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2197"/>
         <source>&amp;Display Controls</source>
         <translation>&amp;Afficher les points de contrôle</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2200"/>
         <source>Display canvas controls</source>
         <translation>Afficher les points de contrôle du canevas</translation>
     </message>
@@ -1386,42 +1647,52 @@ No camera available in your system</source>
         <translation type="vanished">Afficher tous les points de contrôle du canevas lié à la source actuelle</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2226"/>
         <source>&amp;Sticky Vertices</source>
         <translation>&amp;Sommets collants</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2229"/>
         <source>Enable sticky vertices</source>
         <translation>Activer les sommets collants</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2238"/>
         <source>Show &amp;Test Signal</source>
         <translation>Afficher le signal de &amp;Test</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2241"/>
         <source>Show Test signal</source>
         <translation>Afficher le signal de Test</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2270"/>
         <source>Display &amp;Undo History</source>
         <translation>&amp;Afficher l&apos;historique des opérations</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2280"/>
         <source>Open Conso&amp;le</source>
         <translation>Ouvrir la conso&amp;le</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2291"/>
         <source>Display &amp;Zoom Toolbar</source>
         <translation>Afficher la barre de contrôle du &amp;Zoom</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2301"/>
         <source>&amp;Menu Bar</source>
         <translation>Barre de &amp;Menu</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>Main Layout</source>
         <translation>Vue normale</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2312"/>
         <source>Switch to the Main layout.</source>
         <translation>Passer à la vue normale.</translation>
     </message>
@@ -1450,6 +1721,7 @@ No camera available in your system</source>
         <translation type="vanished">Support technique</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2377"/>
         <source>Documentation</source>
         <translation>Documentation</translation>
     </message>
@@ -1458,18 +1730,22 @@ No camera available in your system</source>
         <translation type="vanished">Soumettre une remarque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2412"/>
         <source>&amp;File</source>
         <translation>&amp;Fichier</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2427"/>
         <source>Open Recents Projects</source>
         <translation>Ouvrir les projets récents</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2434"/>
         <source>Open Recents Videos</source>
         <translation>Ouvrir les vidéo récentes</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2445"/>
         <source>&amp;Edit</source>
         <translation>&amp;Édition</translation>
     </message>
@@ -1486,6 +1762,7 @@ No camera available in your system</source>
         <translation type="vanished">Outils</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2507"/>
         <source>&amp;Window</source>
         <translation>&amp;Fenêtre</translation>
     </message>
@@ -1494,80 +1771,109 @@ No camera available in your system</source>
         <translation type="vanished">Barres de menu</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2531"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2614"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;Barre de menu</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2770"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
         <translation>Ce document a été modifié. Voulez-vous sauvegarder vos changements?</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2792"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2806"/>
         <source>Error reading mapping project file</source>
         <translation>Erreur de lecture du projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2793"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3062"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>Impossible de lire le fichier %1:
 %2.</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2807"/>
         <source>Parse error in file %1:
 
 %2</source>
         <translation>Erreur de syntaxe dans le fichier %1: %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2814"/>
         <source>File loaded</source>
         <translation>Fichier chargé</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2843"/>
         <source>Error saving mapping project</source>
         <translation>Erreur en sauvegardant le fichier du projet</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2829"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>Impossible d&apos;écrire le fichier %1:%2.</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2844"/>
+        <source>Cannot rename temporary file to %1.</source>
+        <translation>Impossible de renommer le fichier temporaire en %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2849"/>
         <source>File saved</source>
         <translation>Fichier sauvegardé</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2865"/>
         <source>Untitled</source>
         <translation>Sans titre</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
         <source>%1[*] - %2</source>
         <translation>%1[*] - %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3061"/>
         <source>MapMap Project</source>
         <translation>Projet MapMap</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2903"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2935"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2989"/>
         <source>&amp;%1 %2</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2920"/>
         <source>Clear List</source>
         <translation>Vider la liste</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2923"/>
         <source>No Recents Projects</source>
         <translation>Aucun projet récent</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2956"/>
         <source>%1 - %2x%3</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>File imported</source>
         <translation>Fichier importé</translation>
     </message>
@@ -1576,14 +1882,17 @@ Do you want to save your changes?</source>
         <translation type="vanished">Source de couleur ajoutée</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3497"/>
         <source>Warning</source>
         <translation>Avertissement</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3498"/>
         <source>The following file is not supported: %1</source>
         <translation>Le fichier suivant n&apos;est pas supporté: %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3525"/>
         <source>Cannot load movie</source>
         <translation>Impossible de charger le film</translation>
     </message>
@@ -1593,255 +1902,428 @@ The original file is not found. Will you locate?</source>
         <translation type="obsolete">Impossible d&apos;utiliser le fichier</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3535"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3543"/>
         <source>%1 files (%2)</source>
         <translation>Fichiers %1 (%2)</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3668"/>
         <source>Undo history</source>
         <translation>Historique</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="672"/>
         <source>Camera device</source>
         <translation>Dispositif caméra</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2366"/>
         <source>Report an issue</source>
         <translation>Rapporter un problème</translation>
     </message>
     <message>
         <source>Technical support</source>
-        <translation>Support technique</translation>
+        <translation type="vanished">Support technique</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2380"/>
         <source>Submit feedback via email</source>
         <translation>Soumettre une remarque par courriel</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2484"/>
         <source>&amp;View</source>
         <translation>&amp;Apparence</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>&amp;Output screen</source>
         <translation>&amp;Écran de sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3526"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
         <translation>Impossible d&apos;utiliser le fichier %1.
 Le fichier original est introuvable. Prière de le localiser.</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3541"/>
         <source>Locate file %1</source>
         <translation>Localiser le fichier %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2961"/>
         <source> - Primary</source>
         <translation> - Principal</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1988"/>
+        <source>Solo layer item</source>
+        <translation>Élément de couche en solo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1998"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1999"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2006"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <source>Rotate 90° CW</source>
+        <translation>Pivoter de 90° dans le sens horaire</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2014"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2015"/>
+        <source>Rotate 180°</source>
+        <translation>Pivoter de 180°</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2039"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2041"/>
+        <source>Raise</source>
+        <translation>Monter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2047"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <source>Lower</source>
+        <translation>Descendre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2055"/>
+        <source>Raise to Top</source>
+        <translation>Monter tout en haut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2057"/>
+        <source>Raise to top</source>
+        <translation>Monter tout en haut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <source>Lower to Bottom</source>
+        <translation>Descendre tout en bas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2065"/>
+        <source>Lower to bottom</source>
+        <translation>Descendre tout en bas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2254"/>
+        <source>&amp;Publish Syphon Output</source>
+        <translation>&amp;Publier la sortie Syphon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2255"/>
+        <source>Publish the output composition as a Syphon server other apps can receive</source>
+        <translation>Publier la composition de sortie comme un serveur Syphon que d&apos;autres applications peuvent recevoir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2337"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2339"/>
         <source>Zoom In</source>
         <translation>Agrandir</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2344"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2346"/>
         <source>Zoom Out</source>
         <translation>Réduire</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2351"/>
         <source>Original Size</source>
         <translation>Taille Originale</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2353"/>
         <source>Reset zoom to original size</source>
         <translation>Réinitialiser le zoom à la taille d&apos;origine</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2358"/>
         <source>Fit To View</source>
         <translation>Adapter à la vue</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2359"/>
         <source>Fit to viewport</source>
         <translation>Adapter à la fenêtre</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1621"/>
         <source>Remove this source and all its associated layers?</source>
         <translation>Supprimer cette source et toutes les couches associées ?</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="755"/>
+        <source>Syphon source added</source>
+        <translation>Source Syphon ajoutée</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1693"/>
         <source>Input Editor</source>
         <translation>Éditeur d&apos;entrée</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1709"/>
         <source>Output Editor</source>
         <translation>Éditeur de sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1758"/>
         <source>Library</source>
         <translation>Bibliothèque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Layers</source>
         <translation>Calques</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1885"/>
+        <source>Add a color source...</source>
+        <translation>Ajouter une source de couleur...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1893"/>
+        <source>Add &amp;Syphon Source...</source>
+        <translation>Ajouter une source &amp;Syphon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1896"/>
+        <source>Receive live video from another application via Syphon...</source>
+        <translation>Recevoir de la vidéo en direct d&apos;une autre application via Syphon...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1935"/>
         <source>Duplicate Layer</source>
         <translation>Dupliquer le calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1937"/>
         <source>Duplicate layer item</source>
         <translation>Dupliquer un élément du calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1945"/>
         <source>Delete Layer</source>
         <translation>Supprimer le calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1947"/>
         <source>Delete layer item</source>
         <translation>Supprimer un élément du calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Rename Layer</source>
         <translation>Renommer le calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1957"/>
         <source>Rename layer item</source>
         <translation>Renommer un élément du calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1965"/>
         <source>Lock Layer</source>
         <translation>Vérouiller le calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>Lock layer item</source>
         <translation>Vérouiller un élément du calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1976"/>
         <source>Hide Layer</source>
         <translation>Cacher le calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1977"/>
         <source>Hide layer item</source>
         <translation>Cacher un élément du calque</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1987"/>
         <source>Solo Layer</source>
         <translation>Calque solo</translation>
     </message>
     <message>
         <source>solo layer item</source>
-        <translation>Élement du calque solo</translation>
+        <translation type="vanished">Élement du calque solo</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2072"/>
         <source>Delete Source</source>
         <translation>Supprimer la source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
         <source>Delete source item</source>
         <translation>Supprimer un élément de la source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2082"/>
         <source>Rename Source</source>
         <translation>Renommer la source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2084"/>
         <source>Rename source item</source>
         <translation>Renommer un élément de la source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
         <source>Add &amp;Mesh Layer</source>
         <translation>Ajouter Couche &amp;Maillage</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
         <source>Add mesh layer</source>
         <translation>Ajouter une couche de maillage</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2120"/>
         <source>Add &amp;Triangle Layer</source>
         <translation>Ajouter Couche &amp;Triangle</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2123"/>
         <source>Add triangle layer</source>
         <translation>Ajouter une couche triangulaire</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2131"/>
         <source>Add &amp;Ellipse Layer</source>
         <translation>Ajouter Couche &amp;Ellipse</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2134"/>
         <source>Add ellipse layer</source>
         <translation>Ajouter une couche elliptique</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2211"/>
         <source>&amp;Display Controls of Layers of a Source</source>
         <translation>Commandes d&apos;&amp;affichage des couches d&apos;une source</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2214"/>
         <source>Display all canvas controls related to current source</source>
         <translation>Afficher tous les contrôles de la toile liés à la source actuelle</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2316"/>
         <source>Input editor Layout</source>
         <translation>Couche d&apos;entrée de l&apos;éditeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2319"/>
         <source>Switch to the Input editor Layout.</source>
         <translation>Changer la couche d&apos;entrée de l&apos;éditeur.</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2323"/>
         <source>Output Editor Layout</source>
         <translation>Couche de sortie de l&apos;éditeur</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2326"/>
         <source>Switch to the Output Editors Layout.</source>
         <translation>Changer la couche de sortie de l&apos;éditeur.</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1882"/>
         <source>Add &amp;Color Source...</source>
         <translation>Ajouter &amp;Couleur Source...</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2092"/>
         <source>Import New Media</source>
         <translation>Importer un nouveau média</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2093"/>
         <source>Import new media file if not exists on the list</source>
         <translation>Importer un nouveau média si le fichier n&apos;existe pas sur la liste</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2165"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2168"/>
         <source>Restart</source>
         <translation>Redémarrer</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2369"/>
+        <source>Professional services &amp;&amp; custom development…</source>
+        <translation>Services professionnels &amp;&amp; développement sur mesure…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2370"/>
+        <source>Hire Art Plus Code for video mapping installations, custom features, integration and training</source>
+        <translation>Engagez Art Plus Code pour des installations de mapping vidéo, des fonctionnalités sur mesure, de l&apos;intégration et de la formation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2373"/>
+        <source>Support the project (donate)…</source>
+        <translation>Soutenir le projet (faire un don)…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2374"/>
+        <source>Help fund MapMap&apos;s ongoing development</source>
+        <translation>Aidez à financer le développement continu de MapMap</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2383"/>
+        <source>&amp;Keyboard shortcuts</source>
+        <translation>&amp;Raccourcis clavier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2560"/>
         <source>Change Layer Source</source>
         <translation>Changer la source de la couche</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="3115"/>
         <source>Color source added</source>
         <translation>La couleur de la source a été ajoutée</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2022"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2024"/>
         <source>Flip Horizontally</source>
-        <translation type="unfinished"></translation>
+        <translation>Retourner horizontalement</translation>
     </message>
     <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2031"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2033"/>
         <source>Flip Vertically</source>
-        <translation type="unfinished"></translation>
+        <translation>Retourner verticalement</translation>
     </message>
 </context>
 <context>
     <name>mmp::MapperGLCanvasToolbar</name>
     <message>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="58"/>
         <source>Enlarge the shape</source>
         <translation>Agrandir la forme</translation>
     </message>
     <message>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="66"/>
         <source>Shrink the shape</source>
         <translation>Rétrécir la forme</translation>
     </message>
     <message>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="74"/>
         <source>Reset the shape to the normal size</source>
         <translation>Remettre la forme à sa taille initiale</translation>
     </message>
     <message>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="82"/>
         <source>Fit the shape to content view</source>
         <translation>Ajuster la forme au contenu de la vue</translation>
     </message>
@@ -1850,63 +2332,84 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
     <name>mmp::MappingItemDelegate</name>
     <message>
         <source>Solo mapping</source>
-        <translation>Solo</translation>
+        <translation type="vanished">Solo</translation>
     </message>
     <message>
         <source>Lock mapping</source>
-        <translation>Verrouiller</translation>
+        <translation type="vanished">Verrouiller</translation>
     </message>
     <message>
         <source>Duplicate mapping</source>
-        <translation>Dupliquer</translation>
+        <translation type="vanished">Dupliquer</translation>
     </message>
     <message>
         <source>Delete mapping</source>
-        <translation>Supprimer</translation>
+        <translation type="vanished">Supprimer</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::MeshTextureLayerGui</name>
+    <message>
+        <location filename="../src/gui/LayerGui.cpp" line="428"/>
+        <source>Horizontal</source>
+        <translation>Horizontal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerGui.cpp" line="429"/>
+        <source>Vertical</source>
+        <translation>Vertical</translation>
     </message>
 </context>
 <context>
     <name>mmp::MeshTextureMappingGui</name>
     <message>
         <source>Horizontal</source>
-        <translation>Horizontal</translation>
+        <translation type="vanished">Horizontal</translation>
     </message>
     <message>
         <source>Vertical</source>
-        <translation>Vertical</translation>
+        <translation type="vanished">Vertical</translation>
     </message>
 </context>
 <context>
     <name>mmp::PreferenceDialog</name>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="59"/>
         <source>Preferences</source>
         <translation>Préférences</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="201"/>
         <source>Large</source>
         <translation>Grande</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="202"/>
         <source>Medium</source>
         <translation>Moyenne</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="203"/>
         <source>Small</source>
         <translation>Petite</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Language (requires restart)</source>
         <translation>Langue (redémarrage nécessaire)</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="211"/>
         <source>Toolbar icon size (requires restart)</source>
         <translation>Taille des icônes de la barre d&apos;outils (redémarrage nécessaire)</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="226"/>
         <source>Enable Sticky vertices</source>
         <translation>Activer les sommets collants</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="239"/>
         <source>Sensitivity</source>
         <translation>Sensibilité</translation>
     </message>
@@ -1919,6 +2422,7 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="vanished">Forme</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="457"/>
         <source>Layers</source>
         <translation>Calques</translation>
     </message>
@@ -1927,14 +2431,17 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="vanished">Montrer la résolution sur la sortie vidéo</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="278"/>
         <source>Classic test card</source>
         <translation>Classique</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="279"/>
         <source>PAL test card</source>
         <translation>PAL</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="280"/>
         <source>NTSC test card</source>
         <translation>NTSC</translation>
     </message>
@@ -1943,22 +2450,27 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="vanished">Recevoir les messages OSC</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="378"/>
         <source>on port</source>
         <translation>sur le port</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="381"/>
         <source>Refresh</source>
         <translation>Rafraîchir</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="391"/>
         <source>Local IP</source>
         <translation>IP local</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="405"/>
         <source>OSC Setup</source>
         <translation>Configuration OSC</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="454"/>
         <source>Interface</source>
         <translation>Interface</translation>
     </message>
@@ -1967,22 +2479,27 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="vanished">Mappings et formes</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="460"/>
         <source>Output</source>
         <translation>Sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="463"/>
         <source>Controls</source>
         <translation>Contrôles</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="466"/>
         <source>Advanced</source>
         <translation>Avancé</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="356"/>
         <source>Listen to OSC messages</source>
         <translation>Écouter les messages OSC</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="241"/>
         <source>Vertices</source>
         <translation>Sommets</translation>
     </message>
@@ -1991,32 +2508,176 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="obsolete">Mappings</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="267"/>
         <source>Only show output controls on mouse over</source>
         <translation>Afficher uniquement les contrôles de sortie au passage de la souris</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="272"/>
         <source>Output Layers</source>
         <translation>Couches de sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="276"/>
         <source>Show resolution on output test cards</source>
         <translation>Afficher la résolution sur les cartes de test de sortie</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="309"/>
         <source>Test Card</source>
         <translation>Carte de test</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="363"/>
         <source>Allow message with existing media source</source>
         <translation>Autoriser le message avec la source de média existante</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="366"/>
+        <source>Accept OSC from the network (less secure)</source>
+        <translation>Accepter l&apos;OSC depuis le réseau (moins sécurisé)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="368"/>
+        <source>When off, OSC is only reachable from this computer (127.0.0.1). Enable only on a trusted show network — OSC has no authentication.</source>
+        <translation>Désactivé, l&apos;OSC n&apos;est accessible que depuis cet ordinateur (127.0.0.1). Ne l&apos;activez que sur un réseau de spectacle de confiance — l&apos;OSC n&apos;a aucune authentification.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="371"/>
+        <source>Allow OSC to quit the application</source>
+        <translation>Autoriser l&apos;OSC à quitter l&apos;application</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="373"/>
+        <source>When off, the /mapmap/quit OSC command is ignored so a remote sender cannot close the application during a show.</source>
+        <translation>Désactivé, la commande OSC /mapmap/quit est ignorée afin qu&apos;un émetteur distant ne puisse pas fermer l&apos;application pendant un spectacle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="414"/>
+        <source>Disabled</source>
+        <translation>Désactivé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="418"/>
+        <source>MCP port (0 to disable)</source>
+        <translation>Port MCP (0 pour désactiver)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="426"/>
+        <source>MCP Setup</source>
+        <translation>Configuration MCP</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="440"/>
         <source>Play in loop (requires restart)</source>
         <translation>Jouer en boucle (nécessite un redémarrage)</translation>
     </message>
     <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="448"/>
         <source>Playback</source>
         <translation>Lecture</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::ShortcutWindow</name>
+    <message>
+        <location filename="../src/gui/ShortcutWindow.cpp" line="36"/>
+        <source>%1 - Keyboard Shortcuts</source>
+        <translation>%1 - Raccourcis clavier</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonGui</name>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="254"/>
+        <source>Server</source>
+        <translation>Serveur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="255"/>
+        <source>Status</source>
+        <translation>État</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="257"/>
+        <source>Respect source alpha</source>
+        <translation>Respecter l&apos;alpha de la source</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="304"/>
+        <source>(none)</source>
+        <translation>(aucun)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="310"/>
+        <source>Unknown server</source>
+        <translation>Serveur inconnu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="326"/>
+        <source>Connected</source>
+        <translation>Connecté</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="330"/>
+        <source>No server selected</source>
+        <translation>Aucun serveur sélectionné</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="332"/>
+        <source>Waiting for server…</source>
+        <translation>En attente du serveur…</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonServerDialog</name>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="41"/>
+        <source>Add Syphon Source</source>
+        <translation>Ajouter une source Syphon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="46"/>
+        <source>Choose a Syphon server to receive video from:</source>
+        <translation>Choisissez un serveur Syphon dont recevoir la vidéo :</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="86"/>
+        <source>(Create without connecting yet)</source>
+        <translation>(Créer sans connecter tout de suite)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="91"/>
+        <source>Unknown server</source>
+        <translation>Serveur inconnu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="99"/>
+        <source>Application: %1</source>
+        <translation>Application : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="100"/>
+        <source>Server: %1</source>
+        <translation>Serveur : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="101"/>
+        <source>ID: %1</source>
+        <translation>ID : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="107"/>
+        <source>No Syphon servers found yet. Open a Syphon-enabled app (Resolume, VDMX, a Simple Server, …), or create the source now and connect it later.</source>
+        <translation>Aucun serveur Syphon trouvé pour l&apos;instant. Ouvrez une application compatible Syphon (Resolume, VDMX, un Simple Server, …), ou créez la source maintenant et connectez-la plus tard.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="111"/>
+        <source>%n Syphon server(s) available. The list updates automatically.</source>
+        <translation>
+            <numerusform>%n serveur Syphon disponible. La liste se met à jour automatiquement.</numerusform>
+            <numerusform>%n serveurs Syphon disponibles. La liste se met à jour automatiquement.</numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -2026,18 +2687,22 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
         <translation type="vanished">Fichhier vidéo</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="176"/>
         <source>Video files (%1);;All files (*)</source>
         <translation>Fichiers vidéo (%1);;Tous fichiers (*)</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="180"/>
         <source>Speed (%)</source>
         <translation>VItesse (%)</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="187"/>
         <source>Volume (%)</source>
         <translation>Volume (%)</translation>
     </message>
     <message>
+        <location filename="../src/gui/SourceGui.cpp" line="174"/>
         <source>Source</source>
         <translation>Source</translation>
     </message>

--- a/translations/mapmap_fr.ts
+++ b/translations/mapmap_fr.ts
@@ -55,16 +55,16 @@
         <translation type="vanished">&amp;Nouveau</translation>
     </message>
     <message>
-        <source>&amp;Open...</source>
-        <translation type="vanished">&amp;Ouvrir...</translation>
+        <source>&amp;Open…</source>
+        <translation type="vanished">&amp;Ouvrir…</translation>
     </message>
     <message>
         <source>&amp;Save</source>
         <translation type="vanished">&amp;Sauvegarder</translation>
     </message>
     <message>
-        <source>Save &amp;As...</source>
-        <translation type="vanished">S&amp;auvegarder sous...</translation>
+        <source>Save &amp;As…</source>
+        <translation type="vanished">S&amp;auvegarder sous…</translation>
     </message>
     <message>
         <source>E&amp;xit</source>
@@ -185,8 +185,8 @@ Do you want to save your changes?</source>
         <translation type="vanished">Sauvegarder le projet</translation>
     </message>
     <message>
-        <source>Save the project as...</source>
-        <translation type="vanished">Sauvegarder le projet sous...</translation>
+        <source>Save the project as…</source>
+        <translation type="vanished">Sauvegarder le projet sous…</translation>
     </message>
     <message>
         <source>&amp;Import media source file...</source>
@@ -330,20 +330,20 @@ No camera available in your system</source>
         <translation type="obsolete">Pas de vidéos récentes</translation>
     </message>
     <message>
-        <source>&amp;Import Media File...</source>
-        <translation type="obsolete">Importer un fichier média ...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation type="obsolete">Importer un fichier média …</translation>
     </message>
     <message>
-        <source>Import a video or image file...</source>
-        <translation type="obsolete">Importer un fichier vidéo ou image ...</translation>
+        <source>Import a video or image file…</source>
+        <translation type="obsolete">Importer un fichier vidéo ou image …</translation>
     </message>
     <message>
-        <source>Open &amp;Camera Device...</source>
-        <translation type="obsolete">Ouvrir la &amp;caméra...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation type="obsolete">Ouvrir la &amp;caméra…</translation>
     </message>
     <message>
-        <source>Choose your camera device...</source>
-        <translation type="obsolete">Choisir la caméra...</translation>
+        <source>Choose your camera device…</source>
+        <translation type="obsolete">Choisir la caméra…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -394,12 +394,12 @@ No camera available in your system</source>
         <translation type="vanished">Supprimer la source</translation>
     </message>
     <message>
-        <source>&amp;Preferences...</source>
-        <translation type="vanished">&amp;Préférences...</translation>
+        <source>&amp;Preferences…</source>
+        <translation type="vanished">&amp;Préférences…</translation>
     </message>
     <message>
-        <source>Configure preferences...</source>
-        <translation type="vanished">Configurer préférences...</translation>
+        <source>Configure preferences…</source>
+        <translation type="vanished">Configurer préférences…</translation>
     </message>
     <message>
         <source>Rewind</source>
@@ -1425,8 +1425,8 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1805"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;Ouvrir...</translation>
+        <source>&amp;Open…</source>
+        <translation>&amp;Ouvrir…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1808"/>
@@ -1445,13 +1445,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1825"/>
-        <source>Save &amp;As...</source>
-        <translation>S&amp;auvegarder sous...</translation>
+        <source>Save &amp;As…</source>
+        <translation>S&amp;auvegarder sous…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Save the project as...</source>
-        <translation>Sauvegarder le projet sous...</translation>
+        <source>Save the project as…</source>
+        <translation>Sauvegarder le projet sous…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1857"/>
@@ -1460,23 +1460,23 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1862"/>
-        <source>&amp;Import Media File...</source>
-        <translation>&amp;Importer un fichier média ...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation>&amp;Importer un fichier média …</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Import a video or image file...</source>
-        <translation>Importer un fichier vidéo ou image ...</translation>
+        <source>Import a video or image file…</source>
+        <translation>Importer un fichier vidéo ou image …</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1872"/>
-        <source>Open &amp;Camera Device...</source>
-        <translation>Ajouter une source &amp;caméra...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation>Ajouter une source &amp;caméra…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Choose your camera device...</source>
-        <translation>Choisir la caméra...</translation>
+        <source>Choose your camera device…</source>
+        <translation>Choisir la caméra…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -1570,13 +1570,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2099"/>
-        <source>&amp;Preferences...</source>
-        <translation>&amp;Préférences...</translation>
+        <source>&amp;Preferences…</source>
+        <translation>&amp;Préférences…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2102"/>
-        <source>Configure preferences...</source>
-        <translation>Configurer les préférences...</translation>
+        <source>Configure preferences…</source>
+        <translation>Configurer les préférences…</translation>
     </message>
     <message>
         <source>Add &amp;Mesh</source>
@@ -2084,18 +2084,18 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1885"/>
-        <source>Add a color source...</source>
-        <translation>Ajouter une source de couleur...</translation>
+        <source>Add a color source…</source>
+        <translation>Ajouter une source de couleur…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1893"/>
-        <source>Add &amp;Syphon Source...</source>
-        <translation>Ajouter une source &amp;Syphon...</translation>
+        <source>Add &amp;Syphon Source…</source>
+        <translation>Ajouter une source &amp;Syphon…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1896"/>
-        <source>Receive live video from another application via Syphon...</source>
-        <translation>Recevoir de la vidéo en direct d&apos;une autre application via Syphon...</translation>
+        <source>Receive live video from another application via Syphon…</source>
+        <translation>Recevoir de la vidéo en direct d&apos;une autre application via Syphon…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1935"/>
@@ -2238,8 +2238,8 @@ Le fichier original est introuvable. Prière de le localiser.</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1882"/>
-        <source>Add &amp;Color Source...</source>
-        <translation>Ajouter &amp;Couleur Source...</translation>
+        <source>Add &amp;Color Source…</source>
+        <translation>Ajouter &amp;Couleur Source…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2092"/>

--- a/translations/mapmap_zh_CN.ts
+++ b/translations/mapmap_zh_CN.ts
@@ -4,7 +4,8 @@
 <context>
     <name>FileEdit</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="54"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="55"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="57"/>
         <source>Choose a file</source>
         <translation>选择档案</translation>
     </message>
@@ -12,12 +13,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/app/main.cpp" line="185"/>
+        <location filename="../src/app/main.cpp" line="183"/>
         <source>Initiating program...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../src/app/main.cpp" line="240"/>
+        <location filename="../src/app/main.cpp" line="244"/>
         <source>Done.</source>
         <translation>完成.</translation>
     </message>
@@ -41,28 +42,63 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="144"/>
+        <location filename="../src/core/Commands.cpp" line="148"/>
         <source>Move vertex</source>
         <translation>移动顶点</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="190"/>
+        <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Rotate shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="194"/>
+        <location filename="../src/core/Commands.cpp" line="198"/>
         <source>Scale shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="329"/>
-        <source>Flipped Horizontally</source>
+        <location filename="../src/core/Commands.cpp" line="333"/>
+        <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="334"/>
-        <source>Flipped Vertically</source>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="335"/>
+        <source>Raise layer to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="336"/>
+        <source>Lower layer to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="380"/>
+        <source>Flip Horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="385"/>
+        <source>Flip Vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="424"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="429"/>
+        <source>Rotate 90° CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="434"/>
+        <source>Rotate 180°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -70,17 +106,17 @@
         <translation type="vanished">缩放和旋转形状</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="231"/>
+        <location filename="../src/core/Commands.cpp" line="235"/>
         <source>Move shape</source>
         <translation>移动形状</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="261"/>
+        <location filename="../src/core/Commands.cpp" line="265"/>
         <source>Remove media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="299"/>
+        <location filename="../src/core/Commands.cpp" line="307"/>
         <source>Delete layer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -96,76 +132,81 @@ Shānchú yìngshè
 删除映射</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="154"/>
+        <location filename="../src/core/Layer.cpp" line="148"/>
         <source>Problem at creation of shape.</source>
         <translation>形状问题.</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="170"/>
-        <location filename="../src/core/ProjectReader.cpp" line="169"/>
-        <location filename="../src/core/ProjectReader.cpp" line="198"/>
+        <location filename="../src/core/Layer.cpp" line="160"/>
+        <source>Unable to create shape of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation>失败 &apos;%1&apos;.</translation>
+        <translation type="vanished">失败 &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>The file is not a mapmap version %1 file.</source>
         <translation type="vanished">这个文件不是MapMap %1 文件.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="56"/>
+        <location filename="../src/core/ProjectReader.cpp" line="50"/>
         <source>The contents of this file does not look like a MapMap project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="60"/>
+        <location filename="../src/core/ProjectReader.cpp" line="53"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="72"/>
+        <location filename="../src/core/ProjectReader.cpp" line="178"/>
+        <location filename="../src/core/ProjectReader.cpp" line="187"/>
+        <source>Unable to create layer of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1 Line %2, column %3</translation>
+        <translation type="vanished">%1 Line %2, column %3</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="156"/>
         <source>Problem at creation of paint.</source>
-        <translation>漆问题.</translation>
+        <translation type="vanished">漆问题.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="187"/>
         <source>Problem at creation of mapping.</source>
-        <translation>映射问题.</translation>
+        <translation type="vanished">映射问题.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="44"/>
-        <location filename="../src/gui/PaintGui.cpp" line="38"/>
+        <location filename="../src/gui/LayerGui.cpp" line="44"/>
+        <location filename="../src/gui/SourceGui.cpp" line="42"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="50"/>
-        <location filename="../src/gui/PaintGui.cpp" line="44"/>
+        <location filename="../src/gui/LayerGui.cpp" line="50"/>
+        <location filename="../src/gui/SourceGui.cpp" line="48"/>
         <source>Opacity (%)</source>
         <translation>透明度 (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="63"/>
+        <location filename="../src/gui/LayerGui.cpp" line="63"/>
         <source>Output shape</source>
         <translation>输出形状</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="150"/>
+        <location filename="../src/gui/LayerGui.cpp" line="151"/>
         <source>Point %1</source>
         <translation>点 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="194"/>
+        <location filename="../src/gui/LayerGui.cpp" line="195"/>
         <source>Mesh Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="423"/>
+        <location filename="../src/gui/LayerGui.cpp" line="424"/>
         <source>Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,12 +215,12 @@ Line %2, column %3</source>
         <translation type="vanished">尺寸</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="288"/>
+        <location filename="../src/gui/LayerGui.cpp" line="289"/>
         <source>Input shape</source>
         <translation>输入形状</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="88"/>
+        <location filename="../src/gui/SourceGui.cpp" line="92"/>
         <source>Color</source>
         <translation>色</translation>
     </message>
@@ -356,12 +397,12 @@ Line %2, column %3</source>
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2523"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2521"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2543"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2541"/>
         <source>Select Font</source>
         <translation>选择字体</translation>
     </message>
@@ -626,54 +667,78 @@ Line %2, column %3</source>
         <translation>关于 MapMap %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="82"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="93"/>
         <source>MapMap is a free/open source video mapping software.</source>
         <translation>MapMap 是一个免费软体.</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="84"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
         <translation>Copyright &amp;copy; 2013 %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="94"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>See the </source>
         <translation>请看</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="108"/>
         <source>%1 website</source>
         <translation>%1 website</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="111"/>
+        <source>%1 is developed and sponsored by Art Plus Code. Need a custom video mapping installation, a new feature, integration or training? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="114"/>
+        <source>Hire us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="115"/>
+        <source>Enjoying %1? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="116"/>
+        <source>Support the project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="132"/>
         <source>About</source>
         <translation>关于 MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="119"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="144"/>
         <source>Changelog</source>
         <translation>更新日志</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="137"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="159"/>
         <source>Libraries</source>
         <translation>文库</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="149"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="170"/>
         <source>Contributors</source>
         <translation>合作者</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="161"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="183"/>
         <source>License</source>
         <translation>许可</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="173"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="196"/>
+        <source>OSC Commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>OSC</source>
-        <translation>OSC</translation>
+        <translation type="vanished">OSC</translation>
     </message>
 </context>
 <context>
@@ -699,7 +764,7 @@ Line %2, column %3</source>
         <translation>&amp;档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/ConsoleWindow.cpp" line="101"/>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="104"/>
         <source>MMM dd yy HH:mm</source>
         <translation>MMM dd yy HH:mm</translation>
     </message>
@@ -707,88 +772,116 @@ Line %2, column %3</source>
 <context>
     <name>mmp::ImageGui</name>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="122"/>
+        <location filename="../src/gui/SourceGui.cpp" line="126"/>
         <source>Image file</source>
         <translation>图像档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="124"/>
+        <location filename="../src/gui/SourceGui.cpp" line="128"/>
         <source>Image files (%1);;All files (*)</source>
         <translation>图像档案 (%1);; 全部的档案 (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="128"/>
+        <location filename="../src/gui/SourceGui.cpp" line="132"/>
         <source>Speed (%)</source>
         <translation>速度 (%)</translation>
     </message>
 </context>
 <context>
+    <name>mmp::LayerItemDelegate</name>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="100"/>
+        <source>Solo mapping</source>
+        <translation type="unfinished">单口映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="112"/>
+        <source>Lock mapping</source>
+        <translation type="unfinished">锁定映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="124"/>
+        <source>Duplicate mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="136"/>
+        <source>Delete mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>mmp::MainWindow</name>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="525"/>
-        <location filename="../src/gui/MainWindow.cpp" line="531"/>
+        <location filename="../src/gui/MainWindow.cpp" line="548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="554"/>
         <source>Open project</source>
         <translation>开放</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="527"/>
-        <location filename="../src/gui/MainWindow.cpp" line="533"/>
-        <location filename="../src/gui/MainWindow.cpp" line="565"/>
-        <location filename="../src/gui/MainWindow.cpp" line="571"/>
+        <location filename="../src/gui/MainWindow.cpp" line="550"/>
+        <location filename="../src/gui/MainWindow.cpp" line="556"/>
+        <location filename="../src/gui/MainWindow.cpp" line="588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="594"/>
         <source>MapMap files (*.%1)</source>
         <translation>MapMap 档案 (* %1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="564"/>
-        <location filename="../src/gui/MainWindow.cpp" line="570"/>
+        <location filename="../src/gui/MainWindow.cpp" line="587"/>
+        <location filename="../src/gui/MainWindow.cpp" line="593"/>
         <source>Save project</source>
         <translation>储存档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="601"/>
-        <location filename="../src/gui/MainWindow.cpp" line="609"/>
+        <location filename="../src/gui/MainWindow.cpp" line="624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="632"/>
         <source>Import media source file</source>
         <translation>汇入档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="611"/>
+        <location filename="../src/gui/MainWindow.cpp" line="626"/>
+        <location filename="../src/gui/MainWindow.cpp" line="634"/>
         <source>Media files (%1 %2);;All files (*)</source>
         <translation>媒体文件 (%1 %2);;All files (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="646"/>
+        <location filename="../src/gui/MainWindow.cpp" line="672"/>
         <source>Camera device</source>
         <translation>相机设备</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="647"/>
+        <location filename="../src/gui/MainWindow.cpp" line="673"/>
         <source>Select camera</source>
         <translation>选择相机</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>No camera available</source>
         <translation>没有可用的相机</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>You can not use this feature!
 No camera available in your system</source>
         <translation>系统中没有相机可用</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="684"/>
-        <location filename="../src/gui/MainWindow.cpp" line="688"/>
+        <location filename="../src/gui/MainWindow.cpp" line="717"/>
+        <location filename="../src/gui/MainWindow.cpp" line="721"/>
         <source>Select Color</source>
         <translation>选择颜色</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1449"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1605"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2453"/>
+        <location filename="../src/gui/MainWindow.cpp" line="755"/>
+        <source>Syphon source added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1620"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1781"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2769"/>
         <source>MapMap</source>
         <translation>MapMap</translation>
     </message>
@@ -813,67 +906,67 @@ No camera available in your system</source>
         <translation type="vanished">映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1619"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1795"/>
         <source>&amp;New</source>
         <translation>&amp;新档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1622"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1798"/>
         <source>Create a new project</source>
         <translation>开新档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1805"/>
         <source>&amp;Open...</source>
         <translation>&amp;开放...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1632"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1808"/>
         <source>Open an existing project</source>
         <translation>开现有的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1639"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1815"/>
         <source>&amp;Save</source>
         <translation>&amp;储存档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1642"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1818"/>
         <source>Save the project</source>
         <translation>储存档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1649"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1825"/>
         <source>Save &amp;As...</source>
         <translation>&amp;储存至...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1652"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Save the project as...</source>
         <translation>储存至...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1681"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1857"/>
         <source>No Recents Videos</source>
         <translation>没有最近的影片</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1686"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1862"/>
         <source>&amp;Import Media File...</source>
         <translation>&amp;汇入媒体文件...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1689"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Import a video or image file...</source>
         <translation>导入影片或图像...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1697"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1872"/>
         <source>Open &amp;Camera Device...</source>
         <translation>打开 &amp;相机设备...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1701"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Choose your camera device...</source>
         <translation>选择相机设备...</translation>
     </message>
@@ -882,37 +975,36 @@ No camera available in your system</source>
         <translation type="vanished">加&amp;彩色涂...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1711"/>
         <source>Add a color paint...</source>
-        <translation>加彩色涂...</translation>
+        <translation type="vanished">加彩色涂...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1718"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1904"/>
         <source>E&amp;xit</source>
         <translation>退&amp;出</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1720"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1906"/>
         <source>Exit the application</source>
         <translation>退出应用程序</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>&amp;Undo</source>
         <translation>复原</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1734"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1920"/>
         <source>&amp;Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1741"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1927"/>
         <source>&amp;About MapMap</source>
         <translation>&amp;关于 MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1742"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1928"/>
         <source>Show the application&apos;s About box</source>
         <translation>显示 &apos;关于&apos; 框</translation>
     </message>
@@ -981,12 +1073,12 @@ No camera available in your system</source>
         <translation type="vanished">改漆名</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1855"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2099"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;偏好...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1858"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2102"/>
         <source>Configure preferences...</source>
         <translation>配置偏好...</translation>
     </message>
@@ -1015,14 +1107,14 @@ No camera available in your system</source>
         <translation type="vanished">添加椭圆</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1899"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1902"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2143"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2146"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1910"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2157"/>
         <source>Pause</source>
         <translation>暂停</translation>
     </message>
@@ -1031,22 +1123,22 @@ No camera available in your system</source>
         <translation type="vanished">倒回</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1931"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2175"/>
         <source>Toggle &amp;Fullscreen</source>
         <translation>切换&amp;全屏</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1934"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2178"/>
         <source>Toggle Fullscreen</source>
         <translation>切換全屏</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1952"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2197"/>
         <source>&amp;Display Controls</source>
         <translation>&amp;显示控制</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2200"/>
         <source>Display canvas controls</source>
         <translation>显示画布控制</translation>
     </message>
@@ -1059,52 +1151,52 @@ No camera available in your system</source>
         <translation type="vanished">显示画布的所有控件</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1981"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2226"/>
         <source>&amp;Sticky Vertices</source>
         <translation>&amp;磁性的顶点</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1984"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2229"/>
         <source>Enable sticky vertices</source>
         <translation>启用磁性的顶点</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1993"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2238"/>
         <source>Show &amp;Test Signal</source>
         <translation>显示&amp;测试信号</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1996"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2241"/>
         <source>Show Test signal</source>
         <translation>显示测试信号</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2270"/>
         <source>Display &amp;Undo History</source>
         <translation>显示&amp;撤消历史</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2017"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2280"/>
         <source>Open Conso&amp;le</source>
         <translation>打开&amp;控制台</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2028"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2291"/>
         <source>Display &amp;Zoom Toolbar</source>
         <translation>显示&amp;缩放工具栏</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2038"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2301"/>
         <source>&amp;Menu Bar</source>
         <translation>&amp;选单列</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2045"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>Main Layout</source>
         <translation>基本设计</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2312"/>
         <source>Switch to the Main layout.</source>
         <translation>切换到基本设计.</translation>
     </message>
@@ -1125,403 +1217,504 @@ No camera available in your system</source>
         <translation type="vanished">切换到目的地设计.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1450"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1621"/>
         <source>Remove this source and all its associated layers?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1693"/>
         <source>Input Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1537"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1709"/>
         <source>Output Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1583"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1758"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1584"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1708"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1882"/>
         <source>Add &amp;Color Source...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1749"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1885"/>
+        <source>Add a color source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1893"/>
+        <source>Add &amp;Syphon Source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1896"/>
+        <source>Receive live video from another application via Syphon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1935"/>
         <source>Duplicate Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1751"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1937"/>
         <source>Duplicate layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1945"/>
         <source>Delete Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1761"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1947"/>
         <source>Delete layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1769"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Rename Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1771"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1957"/>
         <source>Rename layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1965"/>
         <source>Lock Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1780"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>Lock layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1790"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1976"/>
         <source>Hide Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1791"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1977"/>
         <source>Hide layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1801"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1987"/>
         <source>Solo Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1802"/>
-        <source>solo layer item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1812"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1813"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2022"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2024"/>
         <source>Flip Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1820"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1821"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2031"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2033"/>
         <source>Flip Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2072"/>
         <source>Delete Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1830"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
         <source>Delete source item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1838"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2082"/>
         <source>Rename Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1840"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2084"/>
         <source>Rename source item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1848"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2092"/>
         <source>Import New Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1849"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2093"/>
         <source>Import new media file if not exists on the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
         <source>Add &amp;Mesh Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1868"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
         <source>Add mesh layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2120"/>
         <source>Add &amp;Triangle Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1879"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2123"/>
         <source>Add triangle layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1887"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2131"/>
         <source>Add &amp;Ellipse Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1890"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2134"/>
         <source>Add ellipse layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1921"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1924"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2165"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2168"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2211"/>
         <source>&amp;Display Controls of Layers of a Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1969"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2214"/>
         <source>Display all canvas controls related to current source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2053"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2316"/>
         <source>Input editor Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2056"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2319"/>
         <source>Switch to the Input editor Layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2060"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2323"/>
         <source>Output Editor Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2326"/>
         <source>Switch to the Output Editors Layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2076"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2337"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2339"/>
         <source>Zoom In</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2081"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2083"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2344"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2346"/>
         <source>Zoom Out</source>
         <translation>缩小
 </translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2088"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2351"/>
         <source>Original Size</source>
         <translation>原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2090"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2353"/>
         <source>Reset zoom to original size</source>
         <translation>重置为原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2358"/>
         <source>Fit To View</source>
         <translation>适合查看</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2096"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2359"/>
         <source>Fit to viewport</source>
         <translation>适合视口</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2103"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2366"/>
         <source>Report an issue</source>
         <translation>回报问题</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2106"/>
         <source>Technical support</source>
-        <translation>支援</translation>
+        <translation type="vanished">支援</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1988"/>
+        <source>Solo layer item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1998"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1999"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2006"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2014"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2015"/>
+        <source>Rotate 180°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2039"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2041"/>
+        <source>Raise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2047"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <source>Lower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2055"/>
+        <source>Raise to Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2057"/>
+        <source>Raise to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <source>Lower to Bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2065"/>
+        <source>Lower to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2254"/>
+        <source>&amp;Publish Syphon Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2255"/>
+        <source>Publish the output composition as a Syphon server other apps can receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2369"/>
+        <source>Professional services &amp;&amp; custom development…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2370"/>
+        <source>Hire Art Plus Code for video mapping installations, custom features, integration and training</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2373"/>
+        <source>Support the project (donate)…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2374"/>
+        <source>Help fund MapMap&apos;s ongoing development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2377"/>
         <source>Documentation</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2380"/>
         <source>Submit feedback via email</source>
         <translation>电子邮件反馈</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2383"/>
+        <source>&amp;Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2412"/>
         <source>&amp;File</source>
         <translation>&amp;档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2427"/>
         <source>Open Recents Projects</source>
         <translation>开最近的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2161"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2434"/>
         <source>Open Recents Videos</source>
         <translation>开最近的影片</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2172"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2445"/>
         <source>&amp;Edit</source>
         <translation>&amp;编辑</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2196"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2484"/>
         <source>&amp;View</source>
         <translation>&amp;视图</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2207"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>&amp;Output screen</source>
         <translation>&amp;输出萤幕</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2216"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2507"/>
         <source>&amp;Window</source>
         <translation>&amp;视窗</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2240"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2531"/>
         <source>&amp;Help</source>
         <translation>&amp;协助</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2268"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2560"/>
         <source>Change Layer Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2614"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;工具列</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2454"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2770"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
         <translation>你想保存你的更改吗?</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2476"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2490"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2792"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2806"/>
         <source>Error reading mapping project file</source>
         <translation>读取文件错误</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2477"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2793"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3062"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>无法读取文件 %1: %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2491"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2807"/>
         <source>Parse error in file %1:
 
 %2</source>
         <translation>解析文件中的错误 %1: %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2814"/>
         <source>File loaded</source>
         <translation>文件加载</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2510"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2843"/>
         <source>Error saving mapping project</source>
         <translation>无法保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2511"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2829"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>不能写入文件 %1: %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2844"/>
+        <source>Cannot rename temporary file to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2849"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2865"/>
         <source>Untitled</source>
         <translation>无名</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
         <source>%1[*] - %2</source>
         <translation>%1[*] - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2726"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3061"/>
         <source>MapMap Project</source>
         <translation>MapMap 方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2571"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2657"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2903"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2935"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2989"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2920"/>
         <source>Clear List</source>
         <translation>清除的列表</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2591"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2923"/>
         <source>No Recents Projects</source>
         <translation>没有最近的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2956"/>
         <source>%1 - %2x%3</source>
         <translation>%1 - %2x%3</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2961"/>
         <source> - Primary</source>
         <translation> - Primary</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2758"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>File imported</source>
         <translation>文件汇入</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3115"/>
         <source>Color source added</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1530,40 +1723,40 @@ Do you want to save your changes?</source>
         <translation type="vanished">彩色漆已添加</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3497"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3498"/>
         <source>The following file is not supported: %1</source>
         <translation>无法打开文件: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3122"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3525"/>
         <source>Cannot load movie</source>
         <translation>无法加载视频</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3123"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3526"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
         <translation>无法使用文件 %1，请找到文件.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3130"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3138"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3541"/>
         <source>Locate file %1</source>
         <translation>定位文件 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3132"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3535"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3543"/>
         <source>%1 files (%2)</source>
         <translation>%1 档案 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3265"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3668"/>
         <source>Undo history</source>
         <translation>撤消历史</translation>
     </message>
@@ -1571,22 +1764,22 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MapperGLCanvasToolbar</name>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="54"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="58"/>
         <source>Enlarge the shape</source>
         <translation>放大形状</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="62"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="66"/>
         <source>Shrink the shape</source>
         <translation>缩小形状</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="70"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="74"/>
         <source>Reset the shape to the normal size</source>
         <translation>重置为原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="78"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="82"/>
         <source>Fit the shape to content view</source>
         <translation>适合内容的形状</translation>
     </message>
@@ -1594,35 +1787,31 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MappingItemDelegate</name>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="99"/>
         <source>Solo mapping</source>
-        <translation>单口映射</translation>
+        <translation type="vanished">单口映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="111"/>
         <source>Lock mapping</source>
-        <translation>锁定映射</translation>
+        <translation type="vanished">锁定映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="123"/>
         <source>Duplicate mapping</source>
-        <translation>重复映射</translation>
+        <translation type="vanished">重复映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="135"/>
         <source>Delete mapping</source>
-        <translation>删除映射</translation>
+        <translation type="vanished">删除映射</translation>
     </message>
 </context>
 <context>
-    <name>mmp::MeshTextureMappingGui</name>
+    <name>mmp::MeshTextureLayerGui</name>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="427"/>
+        <location filename="../src/gui/LayerGui.cpp" line="428"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="428"/>
+        <location filename="../src/gui/LayerGui.cpp" line="429"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1635,42 +1824,42 @@ The original file is not found. Please locate.</source>
         <translation>偏好</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="182"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="201"/>
         <source>Large</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="183"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="202"/>
         <source>Medium</source>
         <translation>中</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="184"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="203"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="188"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Language (requires restart)</source>
         <translation>语言 (必须重新启动)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="192"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="211"/>
         <source>Toolbar icon size (requires restart)</source>
         <translation>工具栏尺寸 (必须重新启动)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="226"/>
         <source>Enable Sticky vertices</source>
         <translation>启用磁性的顶点</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="220"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="239"/>
         <source>Sensitivity</source>
         <translation>灵敏度</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="222"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="241"/>
         <source>Vertices</source>
         <translation>顶点</translation>
     </message>
@@ -1679,87 +1868,122 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">显示分辨率</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="248"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="267"/>
         <source>Only show output controls on mouse over</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="253"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="272"/>
         <source>Output Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="257"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="276"/>
         <source>Show resolution on output test cards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="259"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="278"/>
         <source>Classic test card</source>
         <translation>Classic test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="260"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="279"/>
         <source>PAL test card</source>
         <translation>PAL test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="261"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="280"/>
         <source>NTSC test card</source>
         <translation>NTSC test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="290"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="309"/>
         <source>Test Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="337"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="356"/>
         <source>Listen to OSC messages</source>
         <translation>听OSC的消息</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="344"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="363"/>
         <source>Allow message with existing media source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="349"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="366"/>
+        <source>Accept OSC from the network (less secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="368"/>
+        <source>When off, OSC is only reachable from this computer (127.0.0.1). Enable only on a trusted show network — OSC has no authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="371"/>
+        <source>Allow OSC to quit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="373"/>
+        <source>When off, the /mapmap/quit OSC command is ignored so a remote sender cannot close the application during a show.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="378"/>
         <source>on port</source>
         <translation>on port</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="352"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="381"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="362"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="391"/>
         <source>Local IP</source>
         <translation>本地IP</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="374"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="405"/>
         <source>OSC Setup</source>
         <translation>OSC 体系</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="387"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="414"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="418"/>
+        <source>MCP port (0 to disable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="426"/>
+        <source>MCP Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="440"/>
         <source>Play in loop (requires restart)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="395"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="448"/>
         <source>Playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="401"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="454"/>
         <source>Interface</source>
         <translation>介面</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="404"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="457"/>
         <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1768,19 +1992,120 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="407"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="460"/>
         <source>Output</source>
         <translation>产出</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="410"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="463"/>
         <source>Controls</source>
         <translation>控制</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="413"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="466"/>
         <source>Advanced</source>
         <translation>高级设置</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::ShortcutWindow</name>
+    <message>
+        <location filename="../src/gui/ShortcutWindow.cpp" line="36"/>
+        <source>%1 - Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonGui</name>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="254"/>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="255"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="257"/>
+        <source>Respect source alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="304"/>
+        <source>(none)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="310"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="326"/>
+        <source>Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="330"/>
+        <source>No server selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="332"/>
+        <source>Waiting for server…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonServerDialog</name>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="41"/>
+        <source>Add Syphon Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="46"/>
+        <source>Choose a Syphon server to receive video from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="86"/>
+        <source>(Create without connecting yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="91"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="99"/>
+        <source>Application: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="100"/>
+        <source>Server: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="101"/>
+        <source>ID: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="107"/>
+        <source>No Syphon servers found yet. Open a Syphon-enabled app (Resolume, VDMX, a Simple Server, …), or create the source now and connect it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="111"/>
+        <source>%n Syphon server(s) available. The list updates automatically.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -1790,22 +2115,22 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">影片档案</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="170"/>
+        <location filename="../src/gui/SourceGui.cpp" line="174"/>
         <source>Source</source>
         <translation type="unfinished">来源</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="172"/>
+        <location filename="../src/gui/SourceGui.cpp" line="176"/>
         <source>Video files (%1);;All files (*)</source>
         <translation>影片档案 (%1);; 全部的档案 (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="176"/>
+        <location filename="../src/gui/SourceGui.cpp" line="180"/>
         <source>Speed (%)</source>
         <translation>速度 (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="183"/>
+        <location filename="../src/gui/SourceGui.cpp" line="187"/>
         <source>Volume (%)</source>
         <translation>音量 (%)</translation>
     </message>

--- a/translations/mapmap_zh_CN.ts
+++ b/translations/mapmap_zh_CN.ts
@@ -917,8 +917,8 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1805"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;开放...</translation>
+        <source>&amp;Open…</source>
+        <translation>&amp;开放…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1808"/>
@@ -937,13 +937,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1825"/>
-        <source>Save &amp;As...</source>
-        <translation>&amp;储存至...</translation>
+        <source>Save &amp;As…</source>
+        <translation>&amp;储存至…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Save the project as...</source>
-        <translation>储存至...</translation>
+        <source>Save the project as…</source>
+        <translation>储存至…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1857"/>
@@ -952,23 +952,23 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1862"/>
-        <source>&amp;Import Media File...</source>
-        <translation>&amp;汇入媒体文件...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation>&amp;汇入媒体文件…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Import a video or image file...</source>
-        <translation>导入影片或图像...</translation>
+        <source>Import a video or image file…</source>
+        <translation>导入影片或图像…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1872"/>
-        <source>Open &amp;Camera Device...</source>
-        <translation>打开 &amp;相机设备...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation>打开 &amp;相机设备…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Choose your camera device...</source>
-        <translation>选择相机设备...</translation>
+        <source>Choose your camera device…</source>
+        <translation>选择相机设备…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -1074,13 +1074,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2099"/>
-        <source>&amp;Preferences...</source>
-        <translation>&amp;偏好...</translation>
+        <source>&amp;Preferences…</source>
+        <translation>&amp;偏好…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2102"/>
-        <source>Configure preferences...</source>
-        <translation>配置偏好...</translation>
+        <source>Configure preferences…</source>
+        <translation>配置偏好…</translation>
     </message>
     <message>
         <source>Add &amp;Mesh</source>
@@ -1243,22 +1243,22 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1882"/>
-        <source>Add &amp;Color Source...</source>
+        <source>Add &amp;Color Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1885"/>
-        <source>Add a color source...</source>
+        <source>Add a color source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1893"/>
-        <source>Add &amp;Syphon Source...</source>
+        <source>Add &amp;Syphon Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1896"/>
-        <source>Receive live video from another application via Syphon...</source>
+        <source>Receive live video from another application via Syphon…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mapmap_zh_TW.ts
+++ b/translations/mapmap_zh_TW.ts
@@ -919,8 +919,8 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1805"/>
-        <source>&amp;Open...</source>
-        <translation>&amp;開放...</translation>
+        <source>&amp;Open…</source>
+        <translation>&amp;開放…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1808"/>
@@ -939,13 +939,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1825"/>
-        <source>Save &amp;As...</source>
-        <translation>&amp;儲存至...</translation>
+        <source>Save &amp;As…</source>
+        <translation>&amp;儲存至…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1828"/>
-        <source>Save the project as...</source>
-        <translation>儲存至...</translation>
+        <source>Save the project as…</source>
+        <translation>儲存至…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1857"/>
@@ -954,23 +954,23 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1862"/>
-        <source>&amp;Import Media File...</source>
-        <translation>&amp;匯入媒體文件...</translation>
+        <source>&amp;Import Media File…</source>
+        <translation>&amp;匯入媒體文件…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1865"/>
-        <source>Import a video or image file...</source>
-        <translation>導入影片或圖像...</translation>
+        <source>Import a video or image file…</source>
+        <translation>導入影片或圖像…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1872"/>
-        <source>Open &amp;Camera Device...</source>
-        <translation>打開 &amp;相機設備...</translation>
+        <source>Open &amp;Camera Device…</source>
+        <translation>打開 &amp;相機設備…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1876"/>
-        <source>Choose your camera device...</source>
-        <translation>選擇相機設備...</translation>
+        <source>Choose your camera device…</source>
+        <translation>選擇相機設備…</translation>
     </message>
     <message>
         <source>Add &amp;Color Paint...</source>
@@ -1076,13 +1076,13 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2099"/>
-        <source>&amp;Preferences...</source>
-        <translation>&amp;偏好...</translation>
+        <source>&amp;Preferences…</source>
+        <translation>&amp;偏好…</translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="2102"/>
-        <source>Configure preferences...</source>
-        <translation>配置偏好...</translation>
+        <source>Configure preferences…</source>
+        <translation>配置偏好…</translation>
     </message>
     <message>
         <source>Add &amp;Mesh</source>
@@ -1245,22 +1245,22 @@ No camera available in your system</source>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1882"/>
-        <source>Add &amp;Color Source...</source>
+        <source>Add &amp;Color Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1885"/>
-        <source>Add a color source...</source>
+        <source>Add a color source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1893"/>
-        <source>Add &amp;Syphon Source...</source>
+        <source>Add &amp;Syphon Source…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/gui/MainWindow.cpp" line="1896"/>
-        <source>Receive live video from another application via Syphon...</source>
+        <source>Receive live video from another application via Syphon…</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/translations/mapmap_zh_TW.ts
+++ b/translations/mapmap_zh_TW.ts
@@ -4,7 +4,8 @@
 <context>
     <name>FileEdit</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="54"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="55"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser-extension/fileedit.cpp" line="57"/>
         <source>Choose a file</source>
         <translation>選擇檔案</translation>
     </message>
@@ -12,12 +13,12 @@
 <context>
     <name>QObject</name>
     <message>
-        <location filename="../src/app/main.cpp" line="185"/>
+        <location filename="../src/app/main.cpp" line="183"/>
         <source>Initiating program...</source>
         <translation>启动程序...</translation>
     </message>
     <message>
-        <location filename="../src/app/main.cpp" line="240"/>
+        <location filename="../src/app/main.cpp" line="244"/>
         <source>Done.</source>
         <translation>完成.</translation>
     </message>
@@ -49,28 +50,63 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="144"/>
+        <location filename="../src/core/Commands.cpp" line="148"/>
         <source>Move vertex</source>
         <translation>移動頂點</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="190"/>
+        <location filename="../src/core/Commands.cpp" line="194"/>
         <source>Rotate shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="194"/>
+        <location filename="../src/core/Commands.cpp" line="198"/>
         <source>Scale shape</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="329"/>
-        <source>Flipped Horizontally</source>
+        <location filename="../src/core/Commands.cpp" line="333"/>
+        <source>Raise layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../src/core/Commands.cpp" line="334"/>
-        <source>Flipped Vertically</source>
+        <source>Lower layer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="335"/>
+        <source>Raise layer to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="336"/>
+        <source>Lower layer to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="380"/>
+        <source>Flip Horizontally</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="385"/>
+        <source>Flip Vertically</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="424"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="429"/>
+        <source>Rotate 90° CCW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/core/Commands.cpp" line="434"/>
+        <source>Rotate 180°</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -78,17 +114,17 @@
         <translation type="vanished">缩放和旋转形状</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="231"/>
+        <location filename="../src/core/Commands.cpp" line="235"/>
         <source>Move shape</source>
         <translation>移動形状</translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="261"/>
+        <location filename="../src/core/Commands.cpp" line="265"/>
         <source>Remove media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/Commands.cpp" line="299"/>
+        <location filename="../src/core/Commands.cpp" line="307"/>
         <source>Delete layer</source>
         <translation type="unfinished"></translation>
     </message>
@@ -101,76 +137,81 @@
         <translation type="vanished">刪除映射</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="154"/>
+        <location filename="../src/core/Layer.cpp" line="148"/>
         <source>Problem at creation of shape.</source>
         <translation>形狀問題.</translation>
     </message>
     <message>
-        <location filename="../src/core/Mapping.cpp" line="170"/>
-        <location filename="../src/core/ProjectReader.cpp" line="169"/>
-        <location filename="../src/core/ProjectReader.cpp" line="198"/>
+        <location filename="../src/core/Layer.cpp" line="160"/>
+        <source>Unable to create shape of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>Unable to create paint of type &apos;%1&apos;.</source>
-        <translation>失敗 &apos;%1&apos;.</translation>
+        <translation type="vanished">失敗 &apos;%1&apos;.</translation>
     </message>
     <message>
         <source>The file is not a mapmap version %1 file.</source>
         <translation type="vanished">這個文件不是MapMap %1 文件.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="56"/>
+        <location filename="../src/core/ProjectReader.cpp" line="50"/>
         <source>The contents of this file does not look like a MapMap project.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="60"/>
+        <location filename="../src/core/ProjectReader.cpp" line="53"/>
         <source>The version of MapMap %1 used to save this file is not readable by this MapMap version %2.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="72"/>
+        <location filename="../src/core/ProjectReader.cpp" line="178"/>
+        <location filename="../src/core/ProjectReader.cpp" line="187"/>
+        <source>Unable to create layer of type &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>%1
 Line %2, column %3</source>
-        <translation>%1 Line %2, column %3</translation>
+        <translation type="vanished">%1 Line %2, column %3</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="156"/>
         <source>Problem at creation of paint.</source>
-        <translation>漆問題.</translation>
+        <translation type="vanished">漆問題.</translation>
     </message>
     <message>
-        <location filename="../src/core/ProjectReader.cpp" line="187"/>
         <source>Problem at creation of mapping.</source>
-        <translation>映射問題.</translation>
+        <translation type="vanished">映射問題.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="44"/>
-        <location filename="../src/gui/PaintGui.cpp" line="38"/>
+        <location filename="../src/gui/LayerGui.cpp" line="44"/>
+        <location filename="../src/gui/SourceGui.cpp" line="42"/>
         <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="50"/>
-        <location filename="../src/gui/PaintGui.cpp" line="44"/>
+        <location filename="../src/gui/LayerGui.cpp" line="50"/>
+        <location filename="../src/gui/SourceGui.cpp" line="48"/>
         <source>Opacity (%)</source>
         <translation>透明度 (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="63"/>
+        <location filename="../src/gui/LayerGui.cpp" line="63"/>
         <source>Output shape</source>
         <translation>輸出形狀</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="150"/>
+        <location filename="../src/gui/LayerGui.cpp" line="151"/>
         <source>Point %1</source>
         <translation>點 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="194"/>
+        <location filename="../src/gui/LayerGui.cpp" line="195"/>
         <source>Mesh Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="423"/>
+        <location filename="../src/gui/LayerGui.cpp" line="424"/>
         <source>Subdivisions</source>
         <translation type="unfinished"></translation>
     </message>
@@ -179,12 +220,12 @@ Line %2, column %3</source>
         <translation type="vanished">尺寸</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="288"/>
+        <location filename="../src/gui/LayerGui.cpp" line="289"/>
         <source>Input shape</source>
         <translation>輸入形狀</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="88"/>
+        <location filename="../src/gui/SourceGui.cpp" line="92"/>
         <source>Color</source>
         <translation>色</translation>
     </message>
@@ -358,12 +399,12 @@ Line %2, column %3</source>
 <context>
     <name>QtFontEditWidget</name>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2523"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2521"/>
         <source>...</source>
         <translation>...</translation>
     </message>
     <message>
-        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2543"/>
+        <location filename="../src/gui/contrib/qtpropertybrowser/src/qteditorfactory.cpp" line="2541"/>
         <source>Select Font</source>
         <translation>選擇字體</translation>
     </message>
@@ -628,54 +669,78 @@ Line %2, column %3</source>
         <translation>關於 MapMap %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="82"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="93"/>
         <source>MapMap is a free/open source video mapping software.</source>
         <translation>MapMap 是一個免費軟體.</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="84"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
         <source>Copyright &amp;copy; 2013 %1.</source>
         <translation>Copyright &amp;copy; 2013 %1.</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="94"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
         <source>See the </source>
         <translation>請看</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="95"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="108"/>
         <source>%1 website</source>
         <translation>%1 website</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="107"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="111"/>
+        <source>%1 is developed and sponsored by Art Plus Code. Need a custom video mapping installation, a new feature, integration or training? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="114"/>
+        <source>Hire us</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="115"/>
+        <source>Enjoying %1? </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="116"/>
+        <source>Support the project</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/AboutDialog.cpp" line="132"/>
         <source>About</source>
         <translation>關於 MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="119"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="144"/>
         <source>Changelog</source>
         <translation>更新日誌</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="137"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="159"/>
         <source>Libraries</source>
         <translation>文庫</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="149"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="170"/>
         <source>Contributors</source>
         <translation>合作者</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="161"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="183"/>
         <source>License</source>
         <translation>許可</translation>
     </message>
     <message>
-        <location filename="../src/gui/AboutDialog.cpp" line="173"/>
+        <location filename="../src/gui/AboutDialog.cpp" line="196"/>
+        <source>OSC Commands</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <source>OSC</source>
-        <translation>OSC</translation>
+        <translation type="vanished">OSC</translation>
     </message>
 </context>
 <context>
@@ -701,7 +766,7 @@ Line %2, column %3</source>
         <translation>&amp;檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/ConsoleWindow.cpp" line="101"/>
+        <location filename="../src/gui/ConsoleWindow.cpp" line="104"/>
         <source>MMM dd yy HH:mm</source>
         <translation>MMM dd yy HH:mm</translation>
     </message>
@@ -709,88 +774,116 @@ Line %2, column %3</source>
 <context>
     <name>mmp::ImageGui</name>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="122"/>
+        <location filename="../src/gui/SourceGui.cpp" line="126"/>
         <source>Image file</source>
         <translation>圖像檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="124"/>
+        <location filename="../src/gui/SourceGui.cpp" line="128"/>
         <source>Image files (%1);;All files (*)</source>
         <translation>圖像檔案 (%1);; 全部的檔案 (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="128"/>
+        <location filename="../src/gui/SourceGui.cpp" line="132"/>
         <source>Speed (%)</source>
         <translation>速度 (%)</translation>
     </message>
 </context>
 <context>
+    <name>mmp::LayerItemDelegate</name>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="100"/>
+        <source>Solo mapping</source>
+        <translation type="unfinished">單口映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="112"/>
+        <source>Lock mapping</source>
+        <translation type="unfinished">鎖定映射</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="124"/>
+        <source>Duplicate mapping</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/LayerItemDelegate.cpp" line="136"/>
+        <source>Delete mapping</source>
+        <translation type="unfinished">刪除映射</translation>
+    </message>
+</context>
+<context>
     <name>mmp::MainWindow</name>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="525"/>
-        <location filename="../src/gui/MainWindow.cpp" line="531"/>
+        <location filename="../src/gui/MainWindow.cpp" line="548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="554"/>
         <source>Open project</source>
         <translation>開放</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="527"/>
-        <location filename="../src/gui/MainWindow.cpp" line="533"/>
-        <location filename="../src/gui/MainWindow.cpp" line="565"/>
-        <location filename="../src/gui/MainWindow.cpp" line="571"/>
+        <location filename="../src/gui/MainWindow.cpp" line="550"/>
+        <location filename="../src/gui/MainWindow.cpp" line="556"/>
+        <location filename="../src/gui/MainWindow.cpp" line="588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="594"/>
         <source>MapMap files (*.%1)</source>
         <translation>MapMap 檔案 (* %1)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="564"/>
-        <location filename="../src/gui/MainWindow.cpp" line="570"/>
+        <location filename="../src/gui/MainWindow.cpp" line="587"/>
+        <location filename="../src/gui/MainWindow.cpp" line="593"/>
         <source>Save project</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="601"/>
-        <location filename="../src/gui/MainWindow.cpp" line="609"/>
+        <location filename="../src/gui/MainWindow.cpp" line="624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="632"/>
         <source>Import media source file</source>
         <translation>匯入檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="611"/>
+        <location filename="../src/gui/MainWindow.cpp" line="626"/>
+        <location filename="../src/gui/MainWindow.cpp" line="634"/>
         <source>Media files (%1 %2);;All files (*)</source>
         <translation>媒體文件 (%1 %2);;All files (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="646"/>
+        <location filename="../src/gui/MainWindow.cpp" line="672"/>
         <source>Camera device</source>
         <translation>相機設備</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="647"/>
+        <location filename="../src/gui/MainWindow.cpp" line="673"/>
         <source>Select camera</source>
         <translation>選擇相機</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>No camera available</source>
         <translation>沒有可用的相機</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="658"/>
-        <location filename="../src/gui/MainWindow.cpp" line="669"/>
+        <location filename="../src/gui/MainWindow.cpp" line="687"/>
+        <location filename="../src/gui/MainWindow.cpp" line="702"/>
         <source>You can not use this feature!
 No camera available in your system</source>
         <translation>系統中沒有相機可用</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="684"/>
-        <location filename="../src/gui/MainWindow.cpp" line="688"/>
+        <location filename="../src/gui/MainWindow.cpp" line="717"/>
+        <location filename="../src/gui/MainWindow.cpp" line="721"/>
         <source>Select Color</source>
         <translation>選擇顏色</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1449"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1605"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2453"/>
+        <location filename="../src/gui/MainWindow.cpp" line="755"/>
+        <source>Syphon source added</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1620"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1781"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2769"/>
         <source>MapMap</source>
         <translation>MapMap</translation>
     </message>
@@ -815,67 +908,67 @@ No camera available in your system</source>
         <translation type="vanished">映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1619"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1795"/>
         <source>&amp;New</source>
         <translation>&amp;新檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1622"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1798"/>
         <source>Create a new project</source>
         <translation>開新檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1805"/>
         <source>&amp;Open...</source>
         <translation>&amp;開放...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1632"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1808"/>
         <source>Open an existing project</source>
         <translation>開現有的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1639"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1815"/>
         <source>&amp;Save</source>
         <translation>&amp;儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1642"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1818"/>
         <source>Save the project</source>
         <translation>儲存檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1649"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1825"/>
         <source>Save &amp;As...</source>
         <translation>&amp;儲存至...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1652"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
         <source>Save the project as...</source>
         <translation>儲存至...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1681"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1857"/>
         <source>No Recents Videos</source>
         <translation>沒有最近的影片</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1686"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1862"/>
         <source>&amp;Import Media File...</source>
         <translation>&amp;匯入媒體文件...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1689"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
         <source>Import a video or image file...</source>
         <translation>導入影片或圖像...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1697"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1872"/>
         <source>Open &amp;Camera Device...</source>
         <translation>打開 &amp;相機設備...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1701"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
         <source>Choose your camera device...</source>
         <translation>選擇相機設備...</translation>
     </message>
@@ -884,37 +977,36 @@ No camera available in your system</source>
         <translation type="vanished">加&amp;彩色塗...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1711"/>
         <source>Add a color paint...</source>
-        <translation>加彩色塗...</translation>
+        <translation type="vanished">加彩色塗...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1718"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1904"/>
         <source>E&amp;xit</source>
         <translation>退&amp;出</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1720"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1906"/>
         <source>Exit the application</source>
         <translation>退出應用程序</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
         <source>&amp;Undo</source>
         <translation>复原</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1734"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1920"/>
         <source>&amp;Redo</source>
         <translation>重做</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1741"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1927"/>
         <source>&amp;About MapMap</source>
         <translation>&amp;關於 MapMap</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1742"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1928"/>
         <source>Show the application&apos;s About box</source>
         <translation>顯示 &apos;關於&apos; 框</translation>
     </message>
@@ -983,12 +1075,12 @@ No camera available in your system</source>
         <translation type="vanished">改漆名</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1855"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2099"/>
         <source>&amp;Preferences...</source>
         <translation>&amp;偏好...</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1858"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2102"/>
         <source>Configure preferences...</source>
         <translation>配置偏好...</translation>
     </message>
@@ -1017,14 +1109,14 @@ No camera available in your system</source>
         <translation type="vanished">添加橢圓</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1899"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1902"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2143"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2146"/>
         <source>Play</source>
         <translation>播放</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1910"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1913"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2157"/>
         <source>Pause</source>
         <translation>暫停</translation>
     </message>
@@ -1033,22 +1125,22 @@ No camera available in your system</source>
         <translation type="vanished">倒回</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1931"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2175"/>
         <source>Toggle &amp;Fullscreen</source>
         <translation>切換&amp;全屏</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1934"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2178"/>
         <source>Toggle Fullscreen</source>
         <translation>切換全屏</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1952"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2197"/>
         <source>&amp;Display Controls</source>
         <translation>&amp;顯示控制</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2200"/>
         <source>Display canvas controls</source>
         <translation>顯示畫布控制</translation>
     </message>
@@ -1061,52 +1153,52 @@ No camera available in your system</source>
         <translation type="vanished">顯示畫布的所有控件</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1981"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2226"/>
         <source>&amp;Sticky Vertices</source>
         <translation>&amp;磁性的頂點</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1984"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2229"/>
         <source>Enable sticky vertices</source>
         <translation>啟用磁性的頂點</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1993"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2238"/>
         <source>Show &amp;Test Signal</source>
         <translation>顯示&amp;測試信號</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1996"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2241"/>
         <source>Show Test signal</source>
         <translation>顯示測試信號</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2270"/>
         <source>Display &amp;Undo History</source>
         <translation>顯示&amp;撤消歷史</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2017"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2280"/>
         <source>Open Conso&amp;le</source>
         <translation>打開&amp;控制台</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2028"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2291"/>
         <source>Display &amp;Zoom Toolbar</source>
         <translation>顯示&amp;縮放工具欄</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2038"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2301"/>
         <source>&amp;Menu Bar</source>
         <translation>&amp;選單列</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2045"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
         <source>Main Layout</source>
         <translation>基本設計</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2312"/>
         <source>Switch to the Main layout.</source>
         <translation>切換到基本設計.</translation>
     </message>
@@ -1127,402 +1219,503 @@ No camera available in your system</source>
         <translation type="vanished">切換到目的地設計.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1450"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1621"/>
         <source>Remove this source and all its associated layers?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1693"/>
         <source>Input Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1537"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1709"/>
         <source>Output Editor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1583"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1758"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1584"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
         <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1708"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1882"/>
         <source>Add &amp;Color Source...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1749"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1885"/>
+        <source>Add a color source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1893"/>
+        <source>Add &amp;Syphon Source...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1896"/>
+        <source>Receive live video from another application via Syphon...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1935"/>
         <source>Duplicate Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1751"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1937"/>
         <source>Duplicate layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1759"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1945"/>
         <source>Delete Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1761"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1947"/>
         <source>Delete layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1769"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1955"/>
         <source>Rename Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1771"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1957"/>
         <source>Rename layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1965"/>
         <source>Lock Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1780"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
         <source>Lock layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1790"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1976"/>
         <source>Hide Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1791"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1977"/>
         <source>Hide layer item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1801"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1987"/>
         <source>Solo Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1802"/>
-        <source>solo layer item</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1812"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1813"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2022"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2024"/>
         <source>Flip Horizontally</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1820"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1821"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2031"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2033"/>
         <source>Flip Vertically</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2072"/>
         <source>Delete Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1830"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
         <source>Delete source item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1838"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2082"/>
         <source>Rename Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1840"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2084"/>
         <source>Rename source item</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1848"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2092"/>
         <source>Import New Media</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1849"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2093"/>
         <source>Import new media file if not exists on the list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1865"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
         <source>Add &amp;Mesh Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1868"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
         <source>Add mesh layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1876"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2120"/>
         <source>Add &amp;Triangle Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1879"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2123"/>
         <source>Add triangle layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1887"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2131"/>
         <source>Add &amp;Ellipse Layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1890"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2134"/>
         <source>Add ellipse layer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1921"/>
-        <location filename="../src/gui/MainWindow.cpp" line="1924"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2165"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2168"/>
         <source>Restart</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1966"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2211"/>
         <source>&amp;Display Controls of Layers of a Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="1969"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2214"/>
         <source>Display all canvas controls related to current source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2053"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2316"/>
         <source>Input editor Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2056"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2319"/>
         <source>Switch to the Input editor Layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2060"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2323"/>
         <source>Output Editor Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2326"/>
         <source>Switch to the Output Editors Layout.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2074"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2076"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2337"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2339"/>
         <source>Zoom In</source>
         <translation>放大</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2081"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2083"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2344"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2346"/>
         <source>Zoom Out</source>
         <translation>縮小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2088"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2351"/>
         <source>Original Size</source>
         <translation>原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2090"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2353"/>
         <source>Reset zoom to original size</source>
         <translation>重置為原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2358"/>
         <source>Fit To View</source>
         <translation>適合查看</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2096"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2359"/>
         <source>Fit to viewport</source>
         <translation>適合視口</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2103"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2366"/>
         <source>Report an issue</source>
         <translation>回報問題</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2106"/>
         <source>Technical support</source>
-        <translation>支援</translation>
+        <translation type="vanished">支援</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2109"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1988"/>
+        <source>Solo layer item</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="1998"/>
+        <location filename="../src/gui/MainWindow.cpp" line="1999"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2006"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2007"/>
+        <source>Rotate 90° CW</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2014"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2015"/>
+        <source>Rotate 180°</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2039"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2041"/>
+        <source>Raise</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2047"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2049"/>
+        <source>Lower</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2055"/>
+        <source>Raise to Top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2057"/>
+        <source>Raise to top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2063"/>
+        <source>Lower to Bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2065"/>
+        <source>Lower to bottom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2254"/>
+        <source>&amp;Publish Syphon Output</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2255"/>
+        <source>Publish the output composition as a Syphon server other apps can receive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2369"/>
+        <source>Professional services &amp;&amp; custom development…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2370"/>
+        <source>Hire Art Plus Code for video mapping installations, custom features, integration and training</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2373"/>
+        <source>Support the project (donate)…</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2374"/>
+        <source>Help fund MapMap&apos;s ongoing development</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2377"/>
         <source>Documentation</source>
         <translation>文件</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2112"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2380"/>
         <source>Submit feedback via email</source>
         <translation>電子郵件反饋</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2383"/>
+        <source>&amp;Keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2412"/>
         <source>&amp;File</source>
         <translation>&amp;檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2154"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2427"/>
         <source>Open Recents Projects</source>
         <translation>開最近的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2161"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2434"/>
         <source>Open Recents Videos</source>
         <translation>開最近的影片</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2172"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2445"/>
         <source>&amp;Edit</source>
         <translation>&amp;編輯</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2196"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2484"/>
         <source>&amp;View</source>
         <translation>&amp;視圖</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2207"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
         <source>&amp;Output screen</source>
         <translation>&amp;輸出螢幕</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2216"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2507"/>
         <source>&amp;Window</source>
         <translation>&amp;視窗</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2240"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2531"/>
         <source>&amp;Help</source>
         <translation>&amp;協助</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2268"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2560"/>
         <source>Change Layer Source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2308"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2614"/>
         <source>&amp;Toolbar</source>
         <translation>&amp;工具列</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2454"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2770"/>
         <source>The document has been modified.
 Do you want to save your changes?</source>
         <translation>你想保存你的更改嗎?</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2476"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2490"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2792"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2806"/>
         <source>Error reading mapping project file</source>
         <translation>讀取文件錯誤</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2477"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2727"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2793"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3062"/>
         <source>Cannot read file %1:
 %2.</source>
         <translation>無法讀取文件 %1: %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2491"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2807"/>
         <source>Parse error in file %1:
 
 %2</source>
         <translation>解析文件中的錯誤 %1: %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2498"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2814"/>
         <source>File loaded</source>
         <translation>文件加載</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2510"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2828"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2843"/>
         <source>Error saving mapping project</source>
         <translation>無法保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2511"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2829"/>
         <source>Cannot write file %1:
 %2.</source>
         <translation>不能寫入文件 %1: %2.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2521"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2844"/>
+        <source>Cannot rename temporary file to %1.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/MainWindow.cpp" line="2849"/>
         <source>File saved</source>
         <translation>文件已保存</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2865"/>
         <source>Untitled</source>
         <translation>無名</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
         <source>%1[*] - %2</source>
         <translation>%1[*] - %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2548"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2726"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2880"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3061"/>
         <source>MapMap Project</source>
         <translation>MapMap 方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2571"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2603"/>
-        <location filename="../src/gui/MainWindow.cpp" line="2657"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2903"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2935"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2989"/>
         <source>&amp;%1 %2</source>
         <translation>&amp;%1 %2</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2588"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2920"/>
         <source>Clear List</source>
         <translation>清除的列表</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2591"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2923"/>
         <source>No Recents Projects</source>
         <translation>沒有最近的方案</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2624"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2956"/>
         <source>%1 - %2x%3</source>
         <translation>%1 - %2x%3</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2629"/>
+        <location filename="../src/gui/MainWindow.cpp" line="2961"/>
         <source> - Primary</source>
         <translation> - Primary</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2758"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
         <source>File imported</source>
         <translation>文件匯入</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="2779"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3115"/>
         <source>Color source added</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1531,40 +1724,40 @@ Do you want to save your changes?</source>
         <translation type="vanished">彩色漆已添加</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3094"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3497"/>
         <source>Warning</source>
         <translation>警告</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3095"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3498"/>
         <source>The following file is not supported: %1</source>
         <translation>無法打開文件: %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3122"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3525"/>
         <source>Cannot load movie</source>
         <translation>無法加載視頻</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3123"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3526"/>
         <source>Unable to use file %1.
 The original file is not found. Please locate.</source>
         <translation>無法使用文件 %1，請找到文件.</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3130"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3138"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3533"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3541"/>
         <source>Locate file %1</source>
         <translation>定位文件 %1</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3132"/>
-        <location filename="../src/gui/MainWindow.cpp" line="3140"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3535"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3543"/>
         <source>%1 files (%2)</source>
         <translation>%1 檔案 (%2)</translation>
     </message>
     <message>
-        <location filename="../src/gui/MainWindow.cpp" line="3265"/>
+        <location filename="../src/gui/MainWindow.cpp" line="3668"/>
         <source>Undo history</source>
         <translation>撤消歷史</translation>
     </message>
@@ -1572,22 +1765,22 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MapperGLCanvasToolbar</name>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="54"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="58"/>
         <source>Enlarge the shape</source>
         <translation>放大形狀</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="62"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="66"/>
         <source>Shrink the shape</source>
         <translation>縮小形狀</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="70"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="74"/>
         <source>Reset the shape to the normal size</source>
         <translation>重置為原始大小</translation>
     </message>
     <message>
-        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="78"/>
+        <location filename="../src/gui/MapperGLCanvasToolbar.cpp" line="82"/>
         <source>Fit the shape to content view</source>
         <translation>適合內容的形狀</translation>
     </message>
@@ -1595,35 +1788,31 @@ The original file is not found. Please locate.</source>
 <context>
     <name>mmp::MappingItemDelegate</name>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="99"/>
         <source>Solo mapping</source>
-        <translation>單口映射</translation>
+        <translation type="vanished">單口映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="111"/>
         <source>Lock mapping</source>
-        <translation>鎖定映射</translation>
+        <translation type="vanished">鎖定映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="123"/>
         <source>Duplicate mapping</source>
-        <translation>重複映射</translation>
+        <translation type="vanished">重複映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingItemDelegate.cpp" line="135"/>
         <source>Delete mapping</source>
-        <translation>刪除映射</translation>
+        <translation type="vanished">刪除映射</translation>
     </message>
 </context>
 <context>
-    <name>mmp::MeshTextureMappingGui</name>
+    <name>mmp::MeshTextureLayerGui</name>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="427"/>
+        <location filename="../src/gui/LayerGui.cpp" line="428"/>
         <source>Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/MappingGui.cpp" line="428"/>
+        <location filename="../src/gui/LayerGui.cpp" line="429"/>
         <source>Vertical</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1636,42 +1825,42 @@ The original file is not found. Please locate.</source>
         <translation>偏好</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="182"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="201"/>
         <source>Large</source>
         <translation>大</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="183"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="202"/>
         <source>Medium</source>
         <translation>中</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="184"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="203"/>
         <source>Small</source>
         <translation>小</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="188"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
         <source>Language (requires restart)</source>
         <translation>語言 (必须重新啟動)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="192"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="211"/>
         <source>Toolbar icon size (requires restart)</source>
         <translation>工具欄尺寸 (必须重新啟動)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="207"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="226"/>
         <source>Enable Sticky vertices</source>
         <translation>啟用磁性的頂點</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="220"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="239"/>
         <source>Sensitivity</source>
         <translation>灵敏度</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="222"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="241"/>
         <source>Vertices</source>
         <translation>頂點</translation>
     </message>
@@ -1680,87 +1869,122 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">顯示分辨率</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="248"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="267"/>
         <source>Only show output controls on mouse over</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="253"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="272"/>
         <source>Output Layers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="257"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="276"/>
         <source>Show resolution on output test cards</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="259"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="278"/>
         <source>Classic test card</source>
         <translation>Classic test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="260"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="279"/>
         <source>PAL test card</source>
         <translation>PAL test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="261"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="280"/>
         <source>NTSC test card</source>
         <translation>NTSC test card</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="290"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="309"/>
         <source>Test Card</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="337"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="356"/>
         <source>Listen to OSC messages</source>
         <translation>聽OSC的消息</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="344"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="363"/>
         <source>Allow message with existing media source</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="349"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="366"/>
+        <source>Accept OSC from the network (less secure)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="368"/>
+        <source>When off, OSC is only reachable from this computer (127.0.0.1). Enable only on a trusted show network — OSC has no authentication.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="371"/>
+        <source>Allow OSC to quit the application</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="373"/>
+        <source>When off, the /mapmap/quit OSC command is ignored so a remote sender cannot close the application during a show.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="378"/>
         <source>on port</source>
         <translation>on port</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="352"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="381"/>
         <source>Refresh</source>
         <translation>刷新</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="362"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="391"/>
         <source>Local IP</source>
         <translation>本地IP</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="374"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="405"/>
         <source>OSC Setup</source>
         <translation>OSC 體系</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="387"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="414"/>
+        <source>Disabled</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="418"/>
+        <source>MCP port (0 to disable)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="426"/>
+        <source>MCP Setup</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="440"/>
         <source>Play in loop (requires restart)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="395"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="448"/>
         <source>Playback</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="401"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="454"/>
         <source>Interface</source>
         <translation>介面</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="404"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="457"/>
         <source>Layers</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1769,19 +1993,120 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">映射</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="407"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="460"/>
         <source>Output</source>
         <translation>產出</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="410"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="463"/>
         <source>Controls</source>
         <translation>控制</translation>
     </message>
     <message>
-        <location filename="../src/gui/PreferenceDialog.cpp" line="413"/>
+        <location filename="../src/gui/PreferenceDialog.cpp" line="466"/>
         <source>Advanced</source>
         <translation>高級設置</translation>
+    </message>
+</context>
+<context>
+    <name>mmp::ShortcutWindow</name>
+    <message>
+        <location filename="../src/gui/ShortcutWindow.cpp" line="36"/>
+        <source>%1 - Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonGui</name>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="254"/>
+        <source>Server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="255"/>
+        <source>Status</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="257"/>
+        <source>Respect source alpha</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="304"/>
+        <source>(none)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="310"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="326"/>
+        <source>Connected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="330"/>
+        <source>No server selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SourceGui.cpp" line="332"/>
+        <source>Waiting for server…</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>mmp::SyphonServerDialog</name>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="41"/>
+        <source>Add Syphon Source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="46"/>
+        <source>Choose a Syphon server to receive video from:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="86"/>
+        <source>(Create without connecting yet)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="91"/>
+        <source>Unknown server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="99"/>
+        <source>Application: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="100"/>
+        <source>Server: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="101"/>
+        <source>ID: %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="107"/>
+        <source>No Syphon servers found yet. Open a Syphon-enabled app (Resolume, VDMX, a Simple Server, …), or create the source now and connect it later.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/SyphonServerDialog.cpp" line="111"/>
+        <source>%n Syphon server(s) available. The list updates automatically.</source>
+        <translation type="unfinished">
+            <numerusform></numerusform>
+        </translation>
     </message>
 </context>
 <context>
@@ -1791,22 +2116,22 @@ The original file is not found. Please locate.</source>
         <translation type="vanished">影片檔案</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="170"/>
+        <location filename="../src/gui/SourceGui.cpp" line="174"/>
         <source>Source</source>
         <translation type="unfinished">來源</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="172"/>
+        <location filename="../src/gui/SourceGui.cpp" line="176"/>
         <source>Video files (%1);;All files (*)</source>
         <translation>影片檔案 (%1);; 全部的檔案 (*)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="176"/>
+        <location filename="../src/gui/SourceGui.cpp" line="180"/>
         <source>Speed (%)</source>
         <translation>速度 (%)</translation>
     </message>
     <message>
-        <location filename="../src/gui/PaintGui.cpp" line="183"/>
+        <location filename="../src/gui/SourceGui.cpp" line="187"/>
         <source>Volume (%)</source>
         <translation>音量 (%)</translation>
     </message>


### PR DESCRIPTION
## Summary

An audit-driven hardening pass over MapMap toward a production-ready 1.0. Every change was compiled before landing (targeted object builds plus full macOS builds) and the unit-test suite passes (`make check`, all suites green). The branch applies cleanly on top of `dev` with no divergence.

The static audit that motivated this work lives in `AUDIT.md` (left untracked on purpose).

## Security & show-time stability

The headline risk was the OSC control surface being reachable and fragile on an untrusted venue network.

- **OSC binds to loopback by default; network access is opt-in** (`5038f05`). It previously listened on all interfaces (`QHostAddress::Any`) at launch, so any device on the network could drive — or quit — the show. A new "Accept OSC from the network (less secure)" preference widens it, off by default.
- **The OSC quit command is ignored unless explicitly allowed** (`5e18db7`). `/mapmap/quit` closed the app with no guard; it is now gated behind an off-by-default preference.
- **Malformed OSC packets are dropped instead of unwinding through the event loop** (`c72f4e2`).
- **MCP HTTP server hardened**: requires a loopback Host/Origin (DNS-rebinding guard) plus a per-process bearer token (`609603f`), and is **disabled by default** (`a17dd11`).
- **Top-level exception guard hardened** — logs at `qCritical` and catches non-std exceptions (`9db43f3`).
- **The project loader fails cleanly on corrupt files** — it bails on unconstructable sources/layers instead of dereferencing null (`76dd57b`) and validates vertex/media fields (`ca2e48d`).

## Release & quality

- **Version 1.0.0-alpha.1 from a single source of truth** (`b759cef`), with the file-version regex relaxed so projects saved by pre-release builds still load, plus a compatibility test (`ac2a0bd`).
- **Signal/slot connections migrated to the compile-checked pointer syntax** across the GUI (`3be0929`, `3441c09`); only one private-slot case remains string-based. Migrating also surfaced and fixed a dead `QComboBox::activated(QString)` connection (removed in Qt 6).
- **Project format documented as JSON, not XML** — reader and writer both use `QJsonDocument` (`57e8bc6`).
- **Per-message OSC logging gated behind verbose mode** (`6c06460`).
- **File-open results are checked, not discarded** (`c28a4f2`).
- **Syphon.framework bundle rule emitted once** — removes duplicate-rule build warnings (`7587b22`).

## Internationalization

- **Spanish completed** (`a398879`) and **all five catalogues synced with `lupdate`; French and Spanish now at 350/350** (`b06f4b4`). English falls back to source text; Chinese remains partial.

## UX / onboarding

- **First-run welcome dialog** (`bb50ee1`) that greets the user and points at the first steps, reachable any time from Help > "Welcome to MapMap…", with a matching preference to toggle it and a tooltip explaining the OSC "same media source" option (`f7209c1`).
- **Consistent Unicode ellipsis in action labels**, catalogues patched in lockstep (`776ae1a`).

## Verification

- Full build links on macOS (Qt 6.11); `make check` passes every unit suite.
- Each commit was compiled before it landed.

## Notes / follow-ups

- The bundled example project (part of the welcome-dialog spec) is deferred: it needs a runtime-tested `.mmp` asset.
- Newly added UI strings (welcome dialog, OSC tooltip, welcome preference) need an `lupdate` pass to be translated.
- Deeper fuzzing of the project reader and broader `MainWindow` model-layer test coverage need a headless model-layer test harness.
