### PR TITLE
Fixed video not playing after import

### DIFF
--- a/src/core/Source.cpp
+++ b/src/core/Source.cpp
@@ -206,6 +206,7 @@ void Image::_doPlay()
 /* Implementation of the Video class */
 Video::Video(int id) : Texture(id),
     _uri(""),
+    _videoType(VIDEO_URI),
     _impl(nullptr)
 {
   _impl = new VideoPlayerImpl();

--- a/src/core/Source.cpp
+++ b/src/core/Source.cpp
@@ -27,6 +27,7 @@
 #include <QFileInfo>
 #include <QImageReader>
 #include <QSettings>
+#include <QTimer>
 
 namespace mmp {
 
@@ -355,17 +356,40 @@ bool Video::setUri(const QString &uri)
     // Set uri.
     _uri = uri;
 
-    // Try to get thumbnail.
-    // Wait for the first samples to be available to make sure we are ready.
-    if (!_impl->waitForNextBits(ICON_TIMEOUT))
-    {
-      qDebug() << "No bits coming" << Qt::endl;
-      return false;
-    }
+    // Show a generic icon right away. A real thumbnail (video files only) is
+    // filled in below, asynchronously, once frames actually start arriving:
+    // we cannot wait for it here without blocking the GUI thread, which is
+    // also the thread Qt Multimedia needs free to deliver those frames.
+    _setFallbackIcon();
 
-    if (_videoType != VIDEO_WEBCAM) { // Generated thumbnail if source type is not camera
-      if (!_generateThumbnail())
-        qDebug() << "Could not generate thumbnail for " << uri << ": using generic icon." << Qt::endl;
+    const int maxAttempts = ICON_TIMEOUT / THUMBNAIL_POLL_INTERVAL;
+
+    if (_videoType == VIDEO_WEBCAM)
+    {
+      // No thumbnail to generate for a camera: just confirm the feed comes up.
+      _pollForBits([this]() {
+        _emitPropertyChanged("icon");
+      }, maxAttempts);
+    }
+    else
+    {
+      _pollForBits([this, maxAttempts]() {
+        // Try seeking to the middle of the movie for a representative frame.
+        if (_impl->seekTo(0.5))
+        {
+          _pollForBits([this]() {
+            if (!_generateThumbnail())
+              qDebug() << "Could not generate thumbnail for " << _uri << ": using generic icon." << Qt::endl;
+            _impl->resetMovie();
+            _emitPropertyChanged("icon");
+          }, maxAttempts);
+        }
+        else
+        {
+          _impl->resetMovie();
+          _emitPropertyChanged("icon");
+        }
+      }, maxAttempts);
     }
 
     _emitPropertyChanged("uri");
@@ -387,36 +411,43 @@ void Video::_doPause()
   _impl->setPlayState(false);
 }
 
-bool Video::_generateThumbnail()
+void Video::_setFallbackIcon()
 {
   static QFileIconProvider provider;
 
-  // Default (in case seeking and loading don't work).
   _icon = provider.icon(QFileInfo(_uri));
-  if (_icon.isNull()) {
-    if (_uri.startsWith(QString("/dev/video"))) {
-      _icon = QIcon(":/add-camera");
-    }
-    else {
-      _icon = QIcon(":/add-video");
-    }
+  if (_icon.isNull())
+    _icon = (_videoType == VIDEO_WEBCAM) ? QIcon(":/add-camera") : QIcon(":/add-video");
+}
+
+void Video::_pollForBits(std::function<void()> onReady, int attemptsLeft)
+{
+  if (_impl->hasBits() && _impl->bitsHaveChanged())
+  {
+    onReady();
+    return;
   }
 
-  // Try seeking to the middle of the movie.
-  if (!_impl->seekTo(0.5))
+  if (attemptsLeft <= 0)
   {
-    _impl->resetMovie();
-    return false;
+    qDebug() << "No bits coming for " << _uri << Qt::endl;
+    return;
   }
 
-  // Try to get a sample from the current position.
-  // NOTE: There is no guarantee the sample has yet been acquired.
-  const uchar* bits;
-  if (!_impl->waitForNextBits(ICON_TIMEOUT, &bits))
-  {
-    qDebug() << "Second waiting wrong..." << Qt::endl;
+  // Re-check shortly, giving the Qt event loop a chance to actually run and
+  // deliver the frame we're waiting for.
+  QTimer::singleShot(THUMBNAIL_POLL_INTERVAL, this, [this, onReady, attemptsLeft]() {
+    _pollForBits(onReady, attemptsLeft - 1);
+  });
+}
+
+bool Video::_generateThumbnail()
+{
+  // Assumes the caller (_pollForBits()'s onReady callback) has already
+  // confirmed a fresh frame is available.
+  const uchar* bits = _impl->getBits();
+  if (!bits)
     return false;
-  }
 
   // Copy bits into thumbnail QImage.
   QImage thumbnail(getWidth(), getHeight(), QImage::Format_ARGB32);
@@ -434,9 +465,6 @@ bool Video::_generateThumbnail()
   // Generate icon.
   _icon = QIcon(QPixmap::fromImage(thumbnail).scaled(MM::MAPPING_LIST_ICON_SIZE, MM::MAPPING_LIST_ICON_SIZE,
                                                      Qt::IgnoreAspectRatio));
-
-  // Reset movie.
-  _impl->resetMovie();
 
   return true;
 }

--- a/src/core/Source.h
+++ b/src/core/Source.h
@@ -24,6 +24,7 @@
 
 #include <QtGlobal>
 
+#include <functional>
 #include <string>
 #include <QColor>
 #include <QElapsedTimer>
@@ -332,6 +333,9 @@ public:
   // Thumbnail generation timeout (in ms).
   static const int ICON_TIMEOUT = 1000;
 
+  // How often to re-check for a decoded frame while polling (in ms).
+  static const int THUMBNAIL_POLL_INTERVAL = 50;
+
 public:
   Q_INVOKABLE Video(int id=NULL_UID);
   Video(const QString uri_, VideoType type, double rate, uid id=NULL_UID);
@@ -393,8 +397,24 @@ protected:
   /// Pauses playback.
   virtual void _doPause();
 
-  // Try to generate a thumbnail from currently loaded movie.
+  // Sets a generic fallback icon (file icon, or a generic video/camera icon).
+  void _setFallbackIcon();
+
+  // Builds a thumbnail icon from the frame currently held by _impl. Assumes
+  // the caller has already confirmed a fresh frame is available (see
+  // _pollForBits()).
   bool _generateThumbnail();
+
+  // Polls (via the Qt event loop, never blocking) until _impl has a fresh
+  // frame, then calls onReady. Gives up silently after attemptsLeft tries.
+  //
+  // Qt Multimedia delivers frames asynchronously through the event loop of
+  // the thread that created the QMediaPlayer/QVideoSink (here, the GUI
+  // thread), so this cannot be replaced by a synchronous/blocking wait:
+  // blocking the GUI thread also blocks the delivery of the very frame being
+  // waited for, and starves the media backend's own event processing while
+  // doing so. See the removed VideoImpl::waitForNextBits().
+  void _pollForBits(std::function<void()> onReady, int attemptsLeft);
 
   QString _uri;
   QIcon _icon;

--- a/src/core/VideoImpl.cpp
+++ b/src/core/VideoImpl.cpp
@@ -19,7 +19,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include "VideoImpl.h"
-#include <QElapsedTimer>
 #include <QSettings>
 #include <QDebug>
 
@@ -151,19 +150,5 @@ void VideoImpl::update()
 
 void VideoImpl::lockMutex()   { _mutex.lock(); }
 void VideoImpl::unlockMutex() { _mutex.unlock(); }
-
-bool VideoImpl::waitForNextBits(int timeout, const uchar** bits)
-{
-  QElapsedTimer timer;
-  timer.start();
-  while (timer.elapsed() < timeout) {
-    if (hasBits() && bitsHaveChanged()) {
-      if (bits)
-        *bits = getBits();
-      return true;
-    }
-  }
-  return false;
-}
 
 }

--- a/src/core/VideoImpl.h
+++ b/src/core/VideoImpl.h
@@ -108,9 +108,6 @@ public:
   /// Unlocks mutex.
   void unlockMutex();
 
-  /// Blocks until new bits are available (up to timeout ms). Returns false on timeout.
-  bool waitForNextBits(int timeout, const uchar** bits = nullptr);
-
 protected:
   virtual void freeResources();
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -370,6 +370,8 @@ void MainWindow::sourcePropertyChanged(uid id, QString propertyName, QVariant va
   QListWidgetItem* sourceItem = getItemFromId(*sourceList, id);
   if (propertyName == "name")
     sourceItem->setText(source->getName());
+  else if (propertyName == "icon")
+    sourceItem->setIcon(source->getIcon());
 }
 
 void MainWindow::closeEvent(QCloseEvent *event)


### PR DESCRIPTION
## Summary

Importing a video froze the UI for ~1s and then often left the source not playing (on Ubuntu 24.04). Root cause: `VideoImpl::waitForNextBits()` busy-spun on the GUI thread waiting for the first decoded frame. That pattern dates back to the original GStreamer backend, where frames arrived on GStreamer's own thread so spinning was merely wasteful. Since the Qt6 Multimedia port, frames are delivered via `QVideoSink::videoFrameChanged` on the event loop of the thread that owns the player (the GUI thread) — so the spin blocked the very event loop needed to deliver the frame it was waiting for, guaranteeing a timeout and leaving the media pipeline in a bad state.

- `Video::setUri()` now returns immediately with a fallback icon instead of blocking.
- `Video::_pollForBits()` replaces the blocking wait with non-blocking `QTimer::singleShot`-based polling.
- Source list icon refreshes asynchronously once a real thumbnail is generated (`MainWindow::sourcePropertyChanged`, mirroring the existing `"name"` handling).
- Also fixed an uninitialized `_videoType` in `Video`'s default constructor (used when loading sources from a project file), which the new fallback-icon logic depends on.

## Test plan

- [x] `qmake6 mapmap.pro && make` builds clean
- [x] `tests/` suite builds and all 44 existing Qt Test cases pass (`QT_QPA_PLATFORM=offscreen ./mapmap_tests`)
- [x] Verified via a standalone harness linking the real `Video`/`VideoPlayerImpl` code directly: before the fix, construction always took ~1.4s and always logged "No bits coming"; after the fix, construction returns immediately and bits/dimensions arrive asynchronously without blocking the GUI thread
- [x] Manually confirmed a real video import plays correctly