### PR TITLE
Fixed pause button not working

### DIFF
--- a/src/core/VideoImpl.h
+++ b/src/core/VideoImpl.h
@@ -81,7 +81,7 @@ public:
   /// Loads a new media source. Subclasses override to set up their player.
   virtual bool loadMovie(const QString& filename);
 
-  bool setPlayState(bool play);
+  virtual bool setPlayState(bool play);
   bool getPlayState() const { return _playState; }
 
   bool seekIsEnabled() const { return _seekEnabled; }

--- a/src/core/VideoPlayerImpl.h
+++ b/src/core/VideoPlayerImpl.h
@@ -40,7 +40,7 @@ public:
   bool loadMovie(const QString& path) override;
   bool isLive() override { return false; }
 
-  bool setPlayState(bool play);
+  bool setPlayState(bool play) override;
   bool seekTo(qint64 positionMs) override;
   void setRate(double rate) override;
   void setVolume(double volume) override;


### PR DESCRIPTION
## Summary

`VideoImpl::setPlayState()` wasn't declared `virtual`. `VideoPlayerImpl` declares its own `setPlayState()` that does the real work (`_player->pause()`/`_player->play()`), but since the base wasn't virtual it was just a separate function hiding the base one — never reachable through the `VideoImpl*` pointer that `Video::_doPause()`/`_doPlay()` actually call through. So pausing silently no-opped (just set a bookkeeping flag), while play appeared to work because `VideoPlayerImpl::loadMovie()` calls `_player->play()` directly on load, independent of this path.

Fix: made `VideoImpl::setPlayState()` virtual and added `override` on `VideoPlayerImpl`'s.

## Test plan

- [x] `qmake6 mapmap.pro && make` builds clean
- [x] `tests/` suite builds and all 44 existing Qt Test cases pass
- [x] Standalone dispatch test: calling `setPlayState()` through a `VideoImpl*` base pointer on a `VideoPlayerImpl` with no movie loaded returns `true` (dispatched to the base no-op) before the fix, and `false` (dispatched to the real derived implementation) after — confirmed both ways