### PR TITLE
Fixed degenerate shapes when adding a mapping right after video import

### DIFF
--- a/src/core/Source.cpp
+++ b/src/core/Source.cpp
@@ -252,12 +252,14 @@ void Video::build()
 
 int Video::getWidth() const
 {
-  return this->_impl->getWidth();
+  int w = this->_impl->getWidth();
+  return w > 0 ? w : DEFAULT_WIDTH;
 }
 
 int Video::getHeight() const
 {
-  return this->_impl->getHeight();
+  int h = this->_impl->getHeight();
+  return h > 0 ? h : DEFAULT_HEIGHT;
 }
 
 void Video::update() {
@@ -362,18 +364,24 @@ bool Video::setUri(const QString &uri)
     // also the thread Qt Multimedia needs free to deliver those frames.
     _setFallbackIcon();
 
-    const int maxAttempts = ICON_TIMEOUT / THUMBNAIL_POLL_INTERVAL;
+    const int firstFrameMaxAttempts = FIRST_FRAME_TIMEOUT / THUMBNAIL_POLL_INTERVAL;
+    const int thumbnailMaxAttempts  = ICON_TIMEOUT / THUMBNAIL_POLL_INTERVAL;
 
     if (_videoType == VIDEO_WEBCAM)
     {
       // No thumbnail to generate for a camera: just confirm the feed comes up.
       _pollForBits([this]() {
+        emit frameSizeKnown(getId(), getWidth(), getHeight());
         _emitPropertyChanged("icon");
-      }, maxAttempts);
+      }, firstFrameMaxAttempts);
     }
     else
     {
-      _pollForBits([this, maxAttempts]() {
+      _pollForBits([this, thumbnailMaxAttempts]() {
+        // The first frame just arrived, so getWidth()/getHeight() now report
+        // the real resolution instead of the DEFAULT_WIDTH/HEIGHT placeholder.
+        emit frameSizeKnown(getId(), getWidth(), getHeight());
+
         // Try seeking to the middle of the movie for a representative frame.
         if (_impl->seekTo(0.5))
         {
@@ -382,14 +390,14 @@ bool Video::setUri(const QString &uri)
               qDebug() << "Could not generate thumbnail for " << _uri << ": using generic icon." << Qt::endl;
             _impl->resetMovie();
             _emitPropertyChanged("icon");
-          }, maxAttempts);
+          }, thumbnailMaxAttempts);
         }
         else
         {
           _impl->resetMovie();
           _emitPropertyChanged("icon");
         }
-      }, maxAttempts);
+      }, firstFrameMaxAttempts);
     }
 
     _emitPropertyChanged("uri");

--- a/src/core/Source.h
+++ b/src/core/Source.h
@@ -330,11 +330,25 @@ class Video : public Texture
   Q_PROPERTY(double rate READ getRate WRITE setRate)
 
 public:
-  // Thumbnail generation timeout (in ms).
+  // Thumbnail generation timeout (in ms): how long to wait for the *seeked*
+  // frame once _generateThumbnail() has asked to seek to it. Fine to give up
+  // quickly here — worst case is a generic icon instead of a real thumbnail.
   static const int ICON_TIMEOUT = 1000;
+
+  // How long to wait for the *first* decoded frame (gates both the thumbnail
+  // attempt and frameSizeKnown, i.e. shape auto-fit). Much more generous than
+  // ICON_TIMEOUT: giving up here permanently strands any shape created before
+  // the deadline at the DEFAULT_WIDTH/HEIGHT placeholder, which is a real
+  // mis-crop, not just a missing thumbnail.
+  static const int FIRST_FRAME_TIMEOUT = 15000;
 
   // How often to re-check for a decoded frame while polling (in ms).
   static const int THUMBNAIL_POLL_INTERVAL = 50;
+
+  /// Frame size assumed before the first frame arrives (drives a new mapping's
+  /// initial input shape; auto-fitted once the real resolution is known).
+  static const int DEFAULT_WIDTH  = 640;
+  static const int DEFAULT_HEIGHT = 480;
 
 public:
   Q_INVOKABLE Video(int id=NULL_UID);
@@ -388,6 +402,12 @@ public:
   static bool hasVideoSupport();
 
   virtual QIcon getIcon() const { return _icon; }
+
+signals:
+  /// Emitted once, the first time a real frame's resolution becomes known, so
+  /// the UI can fit input shapes created (at the default size) before any
+  /// frame had arrived.
+  void frameSizeKnown(int sourceId, int width, int height);
 
 protected:
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -822,6 +822,61 @@ void MainWindow::autoFitSyphonInputShapes(int sourceId, int width, int height)
 #endif
 }
 
+void MainWindow::autoFitVideoInputShapes(int sourceId, int width, int height)
+{
+  if (width <= 0 || height <= 0)
+    return;
+
+  Source::ptr source = mappingManager->getSourceById(sourceId);
+  if (source.isNull() || source->getSourceType() != SourceType::Video)
+    return;
+
+  const qreal defW = Video::DEFAULT_WIDTH;
+  const qreal defH = Video::DEFAULT_HEIGHT;
+  const qreal sx = width / defW;
+  const qreal sy = height / defH;
+  const qreal eps = 1.0;
+
+  bool changed = false;
+  QMap<uid, Layer::ptr> layers = mappingManager->getSourceLayers(source);
+  for (QMap<uid, Layer::ptr>::const_iterator it = layers.constBegin();
+       it != layers.constEnd(); ++it)
+  {
+    Layer::ptr layer = it.value();
+    if (layer.isNull() || !layer->hasInputShape())
+      continue;
+
+    MShape::ptr input = layer->getInputShape();
+    QVector<QPointF> verts = input->getVertices();
+    if (verts.isEmpty())
+      continue;
+
+    // Only rescale shapes still at the untouched default size, so we never
+    // clobber a shape the user has already adjusted.
+    qreal minX = verts[0].x(), maxX = verts[0].x();
+    qreal minY = verts[0].y(), maxY = verts[0].y();
+    for (const QPointF& v : verts)
+    {
+      minX = qMin(minX, v.x()); maxX = qMax(maxX, v.x());
+      minY = qMin(minY, v.y()); maxY = qMax(maxY, v.y());
+    }
+    if (qAbs((maxX - minX) - defW) > eps || qAbs((maxY - minY) - defH) > eps)
+      continue;
+
+    for (QPointF& v : verts)
+      v = QPointF(v.x() * sx, v.y() * sy);
+    input->setVertices(verts);
+    input->build();
+    changed = true;
+  }
+
+  if (changed)
+  {
+    updateMappers();
+    updateCanvases();
+  }
+}
+
 void MainWindow::addMesh()
 {
   // A source must be selected to add a mapping.
@@ -3167,6 +3222,15 @@ void MainWindow::addSourceItem(uid sourceId, const QIcon& icon, const QString& n
             this, SLOT(autoFitSyphonInputShapes(int, int, int)),
             Qt::QueuedConnection);
 #endif
+
+  // Fit input shapes once a Video/Camera source's real resolution becomes
+  // known (it may still be the DEFAULT_WIDTH/HEIGHT placeholder if a shape
+  // gets added before the first frame has arrived).
+  if (sourceType == SourceType::Video)
+    connect(qSharedPointerCast<Video>(source).data(),
+            SIGNAL(frameSizeKnown(int, int, int)),
+            this, SLOT(autoFitVideoInputShapes(int, int, int)),
+            Qt::QueuedConnection);
 
   // Add source item to sourceList widget.
   QListWidgetItem* item = new QListWidgetItem(icon, name);

--- a/src/gui/MainWindow.h
+++ b/src/gui/MainWindow.h
@@ -141,6 +141,9 @@ private slots:
   // Fits a Syphon source's input shapes to its real resolution once known.
   void autoFitSyphonInputShapes(int sourceId, int width, int height);
 
+  // Fits a Video/Camera source's input shapes to its real resolution once known.
+  void autoFitVideoInputShapes(int sourceId, int width, int height);
+
   void layerPropertyChanged(uid id, QString propertyName, QVariant value);
   void sourcePropertyChanged(uid id, QString propertyName, QVariant value);
 


### PR DESCRIPTION
## Summary

Stacks on #625. Importing a video and immediately adding a shape (e.g. a circle) for it could create a degenerate shape with all control points collapsed near the same point. Root cause: #625 made video import asynchronous, so right after import `Video::getWidth()`/`getHeight()` can still report -1 (no frame decoded yet) — and shape-creation (`Util::createEllipseForTexture()` etc.) reads those synchronously at the moment the user clicks "Add Ellipse". This is exactly the case the old blocking `waitForNextBits()` used to paper over by guaranteeing valid dimensions before returning.

Fix follows the same pattern already used for Syphon sources in this codebase:
- `Video::getWidth()`/`getHeight()` now fall back to a sane `DEFAULT_WIDTH`/`DEFAULT_HEIGHT` (640×480) placeholder instead of the raw (possibly -1) value from the underlying player, so a shape created before any frame arrives is never degenerate.
- New `Video::frameSizeKnown(sourceId, width, height)` signal, emitted once the first real frame arrives.
- `MainWindow::autoFitVideoInputShapes()` (mirroring the existing `autoFitSyphonInputShapes()`) rescales any input shape still at the untouched default size once the real resolution is known, without touching shapes the user has already adjusted.
- Also split the polling budget: detecting the *first* frame (which gates both the thumbnail and the shape auto-fit) now gets a much more generous 15s budget than the 1s used for the thumbnail's post-seek frame, since giving up on shape auto-fit permanently strands the shape at the wrong size, while giving up on the thumbnail just leaves a generic icon.

## Test plan

- [x] `qmake6 mapmap.pro && make` builds clean
- [x] `tests/` suite builds and all 44 existing Qt Test cases pass
- [x] Standalone harness confirms: `getWidth()`/`getHeight()` return 640×480 immediately after construction (not -1×-1), and `frameSizeKnown` fires with the real dimensions (tested with an 800×600 source) once the frame arrives