### PR TITLE
Fixed upside-down camera image on Linux

### DIFF
--- a/src/core/CameraSurface.cpp
+++ b/src/core/CameraSurface.cpp
@@ -37,18 +37,15 @@ void CameraSurface::onVideoFrameChanged(const QVideoFrame& frame)
   if (img.isNull())
     return;
 
-#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
-  // Qt 6 delivers upright, top-left-origin frames here — the same as the
-  // video-file path (VideoPlayerImpl), which shares the OpenGL upload — so no
-  // flip is needed. The old flip made macOS camera sources appear upside-down.
+  // Qt 6 delivers upright, top-left-origin frames here on every platform —
+  // the same as the video-file path (VideoPlayerImpl), which shares the
+  // OpenGL upload — so no flip is needed. The old flip (a historical OpenGL
+  // orientation workaround, mirror + 180-degree rotation, net a vertical
+  // flip) made camera sources appear upside-down; already removed on
+  // macOS/Windows in f1e51b4, confirmed to be the same bug on Linux by
+  // injecting a synthetic top-red/bottom-blue QVideoFrame directly into this
+  // class and observing the flip.
   _temporaryImage = img;
-#else
-  // Linux: historical orientation fix (kept; adjust if cameras look flipped).
-  QT_WARNING_PUSH
-  QT_WARNING_DISABLE_DEPRECATED
-  _temporaryImage = img.mirrored(true, false).transformed(QTransform().rotate(180));
-  QT_WARNING_POP
-#endif
 }
 
 }


### PR DESCRIPTION
## Summary

`CameraSurface::onVideoFrameChanged()` kept a Linux-only transform (horizontal mirror + 180° rotation, net a vertical flip) inherited from a pre-Qt6 OpenGL orientation workaround. The exact same transform was already identified and removed on macOS in f1e51b4 ("Fix upside-down camera image on macOS") — Qt 6's `QVideoFrame`/`QVideoSink` deliver upright, top-left-origin frames on every platform (same convention the video-file path already relies on unmodified), so the flip only made the image upside-down. That commit left Linux's branch untouched out of caution, with a comment inviting a follow-up ("adjust if cameras look flipped").

Removed the now-platform-wide special case; all platforms use the frame as-is.

## Test plan

- [x] `qmake6 mapmap.pro && make` builds clean
- [x] `tests/` suite builds and all tests pass
- [x] Isolated `CameraSurface::onVideoFrameChanged()` in a standalone harness and fed it a synthetic top-red/bottom-blue `QVideoFrame` directly via `QVideoSink::setVideoFrame()` (bypassing camera hardware/libcamera entirely, which doesn't enumerate the v4l2loopback device available in this environment). Before the fix: red/blue came out swapped (upside down). After the fix: correct orientation.